### PR TITLE
Docker Plugin now totally independent from Kubernetes/Kubectl

### DIFF
--- a/cmd/interlink/main.go
+++ b/cmd/interlink/main.go
@@ -1,17 +1,28 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"log"
 	"net/http"
 
 	commonIL "github.com/intertwin-eu/interlink/pkg/common"
 	"github.com/intertwin-eu/interlink/pkg/interlink"
+	"github.com/sirupsen/logrus"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	logruslogger "github.com/virtual-kubelet/virtual-kubelet/log/logrus"
 )
 
 var Url string
 
 func main() {
+	var cancel context.CancelFunc
+
+	logger := logrus.StandardLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	log.L = logruslogger.FromLogrus(logrus.NewEntry(logger))
+
+	interlink.Ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
 
 	commonIL.NewInterLinkConfig()
 
@@ -25,6 +36,6 @@ func main() {
 
 	err := http.ListenAndServe(":"+commonIL.InterLinkConfigInst.Interlinkport, mutex)
 	if err != nil {
-		log.Fatal(err)
+		log.G(interlink.Ctx).Fatal(err)
 	}
 }

--- a/cmd/sidecars/docker/main.go
+++ b/cmd/sidecars/docker/main.go
@@ -28,7 +28,6 @@ func main() {
 	mutex.HandleFunc("/status", docker.StatusHandler)
 	mutex.HandleFunc("/create", docker.CreateHandler)
 	mutex.HandleFunc("/delete", docker.DeleteHandler)
-	mutex.HandleFunc("/setKubeCFG", docker.SetKubeCFGHandler)
 	err := http.ListenAndServe(":"+commonIL.InterLinkConfigInst.Sidecarport, mutex)
 
 	if err != nil {

--- a/cmd/sidecars/slurm/main.go
+++ b/cmd/sidecars/slurm/main.go
@@ -27,7 +27,6 @@ func main() {
 	mutex.HandleFunc("/status", slurm.StatusHandler)
 	mutex.HandleFunc("/submit", slurm.SubmitHandler)
 	mutex.HandleFunc("/stop", slurm.StopHandler)
-	mutex.HandleFunc("/setKubeCFG", slurm.SetKubeCFGHandler)
 
 	err := http.ListenAndServe(":"+commonIL.InterLinkConfigInst.Sidecarport, mutex)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func main() {
 
 	localClient := kubernetes.NewForConfigOrDie(kubecfg)
 
-	nodeProvider, err := virtualkubelet.NewProvider(cfg.ConfigPath, cfg.NodeName, cfg.OperatingSystem, cfg.InternalIP, cfg.DaemonPort)
+	nodeProvider, err := virtualkubelet.NewProvider(cfg.ConfigPath, cfg.NodeName, cfg.OperatingSystem, cfg.InternalIP, cfg.DaemonPort, ctx)
 	if err != nil {
 		log.G(ctx).Fatal(err)
 	}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -22,10 +22,6 @@ type StatusResponse struct {
 	ReturnVal string      `json:"returnVal"`
 }
 
-type Request struct {
-	Pods map[string]*v1.Pod `json:"pods"`
-}
-
 type GenericRequestType struct {
 	Body string `json:"body"`
 }
@@ -38,12 +34,16 @@ type ConfigMapSecret struct {
 	Mode  fs.FileMode `json:"Mode"`
 }
 
+type RetrievedContainer struct {
+	Name       string         `json:"name"`
+	ConfigMaps []v1.ConfigMap `json:"configMaps"`
+	Secrets    []v1.Secret    `json:"secrets"`
+	EmptyDirs  []string       `json:"emptyDirs"`
+}
+
 type RetrievedPodData struct {
-	Pod           *v1.Pod         `json:"pod"`
-	ContainerName string          `json:"containerName"`
-	ConfigMaps    []*v1.ConfigMap `json:"configMaps"`
-	Secrets       []*v1.Secret    `json:"secrets"`
-	EmptyDirs     []string        `json:"emptyDirs"`
+	Pod        v1.Pod               `json:"pod"`
+	Containers []RetrievedContainer `json:"container"`
 }
 
 type InterLinkConfig struct {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"io/fs"
-
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -24,14 +22,6 @@ type StatusResponse struct {
 
 type GenericRequestType struct {
 	Body string `json:"body"`
-}
-
-type ConfigMapSecret struct {
-	Key   string      `json:"Key"`
-	Value string      `json:"Value"`
-	Path  string      `json:"Path"`
-	Kind  string      `json:"Kind"`
-	Mode  fs.FileMode `json:"Mode"`
 }
 
 type RetrievedContainer struct {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"io/fs"
+
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -10,16 +12,12 @@ const (
 	UNKNOWN = 2
 )
 
-type PodName struct {
-	Name string `json:"podname"`
-}
-
 type PodStatus struct {
-	PodStatus uint `json:"podStatus"`
+	PodName   string `json:"podname"`
+	PodStatus uint   `json:"podStatus"`
 }
 
 type StatusResponse struct {
-	PodName   []PodName   `json:"podname"`
 	PodStatus []PodStatus `json:"podstatus"`
 	ReturnVal string      `json:"returnVal"`
 }
@@ -30,6 +28,22 @@ type Request struct {
 
 type GenericRequestType struct {
 	Body string `json:"body"`
+}
+
+type ConfigMapSecret struct {
+	Key   string      `json:"Key"`
+	Value string      `json:"Value"`
+	Path  string      `json:"Path"`
+	Kind  string      `json:"Kind"`
+	Mode  fs.FileMode `json:"Mode"`
+}
+
+type RetrievedPodData struct {
+	Pod           *v1.Pod
+	ContainerName string `json:"ContainerName"`
+	ConfigMaps    []*v1.ConfigMap
+	Secrets       []*v1.Secret
+	EmptyDirs     []string `json:"EmptyDirs"`
 }
 
 type InterLinkConfig struct {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -39,11 +39,11 @@ type ConfigMapSecret struct {
 }
 
 type RetrievedPodData struct {
-	Pod           *v1.Pod
-	ContainerName string `json:"ContainerName"`
-	ConfigMaps    []*v1.ConfigMap
-	Secrets       []*v1.Secret
-	EmptyDirs     []string `json:"EmptyDirs"`
+	Pod           *v1.Pod         `json:"pod"`
+	ContainerName string          `json:"containerName"`
+	ConfigMaps    []*v1.ConfigMap `json:"configMaps"`
+	Secrets       []*v1.Secret    `json:"secrets"`
+	EmptyDirs     []string        `json:"emptyDirs"`
 }
 
 type InterLinkConfig struct {

--- a/pkg/interlink/create.go
+++ b/pkg/interlink/create.go
@@ -27,21 +27,26 @@ func CreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	var retrieved_data []*commonIL.RetrievedPodData
 	for _, pod := range req2.Pods {
-		data := commonIL.RetrievedPodData{}
+		data := []*commonIL.RetrievedPodData{}
 		if commonIL.InterLinkConfigInst.ExportPodData {
-			data, err := getData(pod)
+			data, err = getData(pod)
 			if err != nil {
 				w.Write([]byte("500"))
 				return
 			}
 			log.Print(data)
 		}
-		data.Pod = pod
-		retrieved_data = append(retrieved_data, &data)
+
+		if data == nil {
+			data = append(data, &commonIL.RetrievedPodData{Pod: pod})
+		}
+
+		retrieved_data = append(retrieved_data, data...)
 	}
 
-	bodybytes, _ := json.Marshal(retrieved_data)
+	bodybytes, err := json.Marshal(retrieved_data)
 	reader = bytes.NewReader(bodybytes)
+	fmt.Println(string(bodyBytes))
 
 	switch commonIL.InterLinkConfigInst.Sidecarservice {
 	case "docker":

--- a/pkg/interlink/func.go
+++ b/pkg/interlink/func.go
@@ -9,8 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func getData(pod *v1.Pod) (*commonIL.RetrievedPodData, error) {
-	var retrieved_data *commonIL.RetrievedPodData
+func getData(pod *v1.Pod) ([]*commonIL.RetrievedPodData, error) {
+	var retrieved_data []*commonIL.RetrievedPodData
 	for _, container := range pod.Spec.Containers {
 		log.G(Ctx).Info("- Retrieving Secrets and ConfigMaps for the Docker Sidecar. Container: " + container.Name)
 
@@ -21,7 +21,8 @@ func getData(pod *v1.Pod) (*commonIL.RetrievedPodData, error) {
 		}
 
 		if data != nil {
-			data.ContainerName = container.Name
+			data.Pod = pod
+			retrieved_data = append(retrieved_data, data)
 		}
 	}
 
@@ -58,6 +59,7 @@ func retrieve_data(container v1.Container, pod *v1.Pod) (*commonIL.RetrievedPodD
 					if retrieved_data == nil {
 						retrieved_data = &commonIL.RetrievedPodData{}
 					}
+					retrieved_data.ContainerName = container.Name
 					retrieved_data.ConfigMaps = append(retrieved_data.ConfigMaps, configMap)
 				}
 
@@ -78,6 +80,7 @@ func retrieve_data(container v1.Container, pod *v1.Pod) (*commonIL.RetrievedPodD
 					if retrieved_data == nil {
 						retrieved_data = &commonIL.RetrievedPodData{}
 					}
+					retrieved_data.ContainerName = container.Name
 					retrieved_data.Secrets = append(retrieved_data.Secrets, secret)
 				}
 
@@ -86,6 +89,7 @@ func retrieve_data(container v1.Container, pod *v1.Pod) (*commonIL.RetrievedPodD
 				if retrieved_data == nil {
 					retrieved_data = &commonIL.RetrievedPodData{}
 				}
+				retrieved_data.ContainerName = container.Name
 				retrieved_data.EmptyDirs = append(retrieved_data.EmptyDirs, edPath)
 			}
 		}

--- a/pkg/interlink/func.go
+++ b/pkg/interlink/func.go
@@ -1,0 +1,95 @@
+package interlink
+
+import (
+	"path/filepath"
+
+	"github.com/containerd/containerd/log"
+	commonIL "github.com/intertwin-eu/interlink/pkg/common"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getData(pod *v1.Pod) (*commonIL.RetrievedPodData, error) {
+	var retrieved_data *commonIL.RetrievedPodData
+	for _, container := range pod.Spec.Containers {
+		log.G(Ctx).Info("- Retrieving Secrets and ConfigMaps for the Docker Sidecar. Container: " + container.Name)
+
+		data, err := retrieve_data(container, pod)
+		if err != nil {
+			log.G(Ctx).Error(err)
+			return nil, err
+		}
+
+		if data != nil {
+			data.ContainerName = container.Name
+		}
+	}
+
+	return retrieved_data, nil
+}
+
+func retrieve_data(container v1.Container, pod *v1.Pod) (*commonIL.RetrievedPodData, error) {
+	var retrieved_data *commonIL.RetrievedPodData
+	for _, mount_var := range container.VolumeMounts {
+		log.G(Ctx).Debug("-- Retrieving data for mountpoint " + mount_var.Name)
+
+		var podVolumeSpec *v1.VolumeSource
+
+		for _, vol := range pod.Spec.Volumes {
+
+			if vol.Name == mount_var.Name {
+				podVolumeSpec = &vol.VolumeSource
+			}
+
+			if podVolumeSpec != nil && podVolumeSpec.ConfigMap != nil {
+				log.G(Ctx).Info("--- Retrieving ConfigMap " + podVolumeSpec.ConfigMap.Name)
+				cmvs := podVolumeSpec.ConfigMap
+
+				configMap, err := Clientset.CoreV1().ConfigMaps(pod.Namespace).Get(cmvs.Name, metav1.GetOptions{})
+
+				if err != nil {
+					log.G(Ctx).Error(err)
+					return nil, err
+				} else {
+					log.G(Ctx).Debug("---- Retrieved ConfigMap " + podVolumeSpec.ConfigMap.Name)
+				}
+
+				if configMap != nil {
+					if retrieved_data == nil {
+						retrieved_data = &commonIL.RetrievedPodData{}
+					}
+					retrieved_data.ConfigMaps = append(retrieved_data.ConfigMaps, configMap)
+				}
+
+			} else if podVolumeSpec != nil && podVolumeSpec.Secret != nil {
+				log.G(Ctx).Info("--- Retrieving Secret " + podVolumeSpec.Secret.SecretName)
+				svs := podVolumeSpec.Secret
+
+				secret, err := Clientset.CoreV1().Secrets(pod.Namespace).Get(svs.SecretName, metav1.GetOptions{})
+
+				if err != nil {
+					log.G(Ctx).Error(err)
+					return nil, err
+				} else {
+					log.G(Ctx).Debug("---- Retrieved Secret " + svs.SecretName)
+				}
+
+				if secret.Data != nil {
+					if retrieved_data == nil {
+						retrieved_data = &commonIL.RetrievedPodData{}
+					}
+					retrieved_data.Secrets = append(retrieved_data.Secrets, secret)
+				}
+
+			} else if podVolumeSpec != nil && podVolumeSpec.EmptyDir != nil {
+				edPath := filepath.Join(commonIL.InterLinkConfigInst.DataRootFolder, pod.Namespace+"-"+string(pod.UID)+"/"+"emptyDirs/"+vol.Name)
+				if retrieved_data == nil {
+					retrieved_data = &commonIL.RetrievedPodData{}
+				}
+				retrieved_data.EmptyDirs = append(retrieved_data.EmptyDirs, edPath)
+			}
+		}
+	}
+
+	return retrieved_data, nil
+}

--- a/pkg/interlink/kubeCFG.go
+++ b/pkg/interlink/kubeCFG.go
@@ -1,50 +1,81 @@
 package interlink
 
 import (
-	"bytes"
-	"fmt"
+	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
-	"time"
+	"os"
+
+	"github.com/containerd/containerd/log"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 
 	commonIL "github.com/intertwin-eu/interlink/pkg/common"
 )
 
 func SetKubeCFGHandler(w http.ResponseWriter, r *http.Request) {
-	log.Println("InterLink: received SetKubeCFG call")
+	log.G(Ctx).Info("InterLink: received SetKubeCFG call")
+	path := "/tmp/.kube/"
+	retCode := "200"
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Fatal(err)
+		log.G(Ctx).Error(err)
 	}
 
-	var req *http.Request
-	reader := bytes.NewReader(bodyBytes)
-	var returnValue []byte
+	var req commonIL.GenericRequestType
+	json.Unmarshal(bodyBytes, &req)
 
-	for {
-		req, err = http.NewRequest(http.MethodPost, commonIL.InterLinkConfigInst.Sidecarurl+":"+commonIL.InterLinkConfigInst.Sidecarport+"/setKubeCFG", reader)
-
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		log.Println("InterLink: forwarding SetKubeCFG call to sidecar")
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			log.Println(err)
-			time.Sleep(5 * time.Second)
-		}
-
-		returnValue, _ = ioutil.ReadAll(resp.Body)
-		fmt.Println(string(returnValue))
-
-		if string(returnValue) == "200" {
-			log.Println("InterLink: received a valid response")
-			break
-		}
-		log.Println("InterLink: received a not valid response: " + string(returnValue))
+	log.G(Ctx).Debug("- Creating folder to save KubeConfig")
+	err = os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		log.G(Ctx).Error(err)
+		retCode = "500"
+		w.Write([]byte(retCode))
+		return
+	} else {
+		log.G(Ctx).Debug("-- Created folder")
+	}
+	log.G(Ctx).Debug("- Creating the actual KubeConfig file")
+	config, err := os.Create(path + "config")
+	if err != nil {
+		log.G(Ctx).Error(err)
+		retCode = "500"
+		w.Write([]byte(retCode))
+		return
+	} else {
+		log.G(Ctx).Debug("-- Created file")
+	}
+	log.G(Ctx).Debug("- Writing configuration to file")
+	_, err = config.Write([]byte(req.Body))
+	if err != nil {
+		log.G(Ctx).Error(err)
+		retCode = "500"
+		w.Write([]byte(retCode))
+		return
+	} else {
+		log.G(Ctx).Info("-- Written configuration")
+	}
+	defer config.Close()
+	log.G(Ctx).Debug("- Setting KUBECONFIG env")
+	err = os.Setenv("KUBECONFIG", path+"config")
+	if err != nil {
+		log.G(Ctx).Error(err)
+		retCode = "500"
+		w.Write([]byte(retCode))
+		return
+	} else {
+		log.G(Ctx).Info("-- Set KUBECONFIG to " + path + "config")
 	}
 
-	w.Write(returnValue)
+	kubeconfig, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	if err != nil {
+		log.G(Ctx).Error("Unable to create a valid config")
+		return
+	}
+	Clientset, err = kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		log.G(Ctx).Fatalln("Unable to set up a clientset")
+	}
+
+	w.Write([]byte(retCode))
 }

--- a/pkg/interlink/vars.go
+++ b/pkg/interlink/vars.go
@@ -1,0 +1,10 @@
+package interlink
+
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+var Ctx context.Context
+var Clientset *kubernetes.Clientset

--- a/pkg/sidecars/docker/aux.go
+++ b/pkg/sidecars/docker/aux.go
@@ -36,6 +36,24 @@ func prepare_mounts(container v1.Container, data commonIL.RetrievedPodData) stri
 		}
 	}
 
+	for _, secret := range data.Secrets {
+		if container.Name == data.ContainerName {
+			mountSecrets(container, data.Pod, secret)
+		}
+	}
+
+	for _, secret := range data.Secrets {
+		if container.Name == data.ContainerName {
+			mountSecrets(container, data.Pod, secret)
+		}
+	}
+
+	for _, emptyDir := range data.EmptyDirs {
+		if container.Name == data.ContainerName {
+			mountEmptyDir(container, data.Pod, emptyDir)
+		}
+	}
+
 	if last := len(mount_data) - 1; last >= 0 && mount_data[last] == ',' {
 		mount_data = mount_data[:last]
 	}
@@ -190,7 +208,7 @@ func mountSecrets(container v1.Container, pod *v1.Pod, secret *v1.Secret) []stri
 	return secretNamePaths
 }
 
-func mountEmptyDir(container v1.Container, pod *v1.Pod) string {
+func mountEmptyDir(container v1.Container, pod *v1.Pod, emptyDir string) string {
 	var edPath string
 
 	if commonIL.InterLinkConfigInst.ExportPodData {

--- a/pkg/sidecars/docker/handlers.go
+++ b/pkg/sidecars/docker/handlers.go
@@ -4,14 +4,11 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 
 	exec "github.com/alexellis/go-execute/pkg/v1"
 	"github.com/containerd/containerd/log"
 	commonIL "github.com/intertwin-eu/interlink/pkg/common"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func StatusHandler(w http.ResponseWriter, r *http.Request) {
@@ -44,19 +41,12 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			if execReturn.Stderr != "" {
-				log.G(Ctx).Error("-- Failed to get status for " + container.Name + " : " + execReturn.Stdout)
+			if execReturn.Stdout == "" {
+				log.G(Ctx).Info("-- Container " + container.Name + " is not running")
+				resp.PodStatus = append(resp.PodStatus, commonIL.PodStatus{PodName: pod.Name, PodStatus: commonIL.STOP})
 			} else {
 				log.G(Ctx).Info("-- Container " + container.Name + " is running")
-			}
-
-			resp.PodName = append(resp.PodName, commonIL.PodName{Name: pod.Name})
-			log.G(Ctx).Debug(execReturn.Stderr, execReturn.Stdout)
-
-			if execReturn.Stdout == "" {
-				resp.PodStatus = append(resp.PodStatus, commonIL.PodStatus{PodStatus: commonIL.STOP})
-			} else {
-				resp.PodStatus = append(resp.PodStatus, commonIL.PodStatus{PodStatus: commonIL.RUNNING})
+				resp.PodStatus = append(resp.PodStatus, commonIL.PodStatus{PodName: pod.Name, PodStatus: commonIL.RUNNING})
 			}
 		}
 	}
@@ -75,16 +65,16 @@ func CreateHandler(w http.ResponseWriter, r *http.Request) {
 		log.G(Ctx).Error(err)
 	}
 
-	var req commonIL.Request
+	var req []commonIL.RetrievedPodData
 	json.Unmarshal(bodyBytes, &req)
 
-	for _, pod := range req.Pods {
-		for _, container := range pod.Spec.Containers {
+	for _, data := range req {
+		for _, container := range data.Pod.Spec.Containers {
 			log.G(Ctx).Info("- Creating container " + container.Name)
 			cmd := []string{"run", "-d", "--name", container.Name}
 
 			if commonIL.InterLinkConfigInst.ExportPodData {
-				cmd = append(cmd, prepare_mounts(container, pod))
+				cmd = append(cmd, prepare_mounts(container, data))
 			}
 
 			cmd = append(cmd, container.Image)
@@ -108,8 +98,13 @@ func CreateHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			if execReturn.Stderr != "" {
-				log.G(Ctx).Error("Unable to create container " + container.Name + " : " + execReturn.Stderr)
+			if execReturn.Stdout == "" {
+				eval := "Conflict. The container name \"/" + container.Name + "\" is already in use"
+				if strings.Contains(execReturn.Stderr, eval) {
+					log.G(Ctx).Warning("Container named " + container.Name + " already exists. Skipping its creation.")
+				} else {
+					log.G(Ctx).Error("Unable to create container " + container.Name + " : " + execReturn.Stderr)
+				}
 			} else {
 				log.G(Ctx).Info("-- Created container " + container.Name)
 			}
@@ -131,10 +126,11 @@ func CreateHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
 	if err != nil {
 		w.Write([]byte(execReturn.Stderr))
 	} else {
-		w.Write([]byte("All containers for submitted Pods have been created"))
+		w.Write([]byte("200"))
 	}
 }
 
@@ -161,7 +157,7 @@ func DeleteHandler(w http.ResponseWriter, r *http.Request) {
 			execReturn, _ = shell.Execute()
 
 			if execReturn.Stderr != "" {
-				log.G(Ctx).Error("-- Error stopping container " + container.Name + ". Skipping its removing")
+				log.G(Ctx).Error("-- Error stopping container " + container.Name + ". Skipping its removal")
 				continue
 			}
 
@@ -187,71 +183,4 @@ func DeleteHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.Write([]byte("All containers for submitted Pods have been deleted"))
 	}
-}
-
-func SetKubeCFGHandler(w http.ResponseWriter, r *http.Request) {
-	log.G(Ctx).Info("Docker Sidecar: received SetKubeCFG call")
-	path := "/tmp/.kube/"
-	retCode := "200"
-	bodyBytes, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.G(Ctx).Error(err)
-	}
-
-	var req commonIL.GenericRequestType
-	json.Unmarshal(bodyBytes, &req)
-
-	log.G(Ctx).Debug("- Creating folder to save KubeConfig")
-	err = os.MkdirAll(path, os.ModePerm)
-	if err != nil {
-		log.G(Ctx).Error(err)
-		retCode = "500"
-		w.Write([]byte(retCode))
-		return
-	} else {
-		log.G(Ctx).Debug("-- Created folder")
-	}
-	log.G(Ctx).Debug("- Creating the actual KubeConfig file")
-	config, err := os.Create(path + "config")
-	if err != nil {
-		log.G(Ctx).Error(err)
-		retCode = "500"
-		w.Write([]byte(retCode))
-		return
-	} else {
-		log.G(Ctx).Debug("-- Created file")
-	}
-	log.G(Ctx).Debug("- Writing configuration to file")
-	_, err = config.Write([]byte(req.Body))
-	if err != nil {
-		log.G(Ctx).Error(err)
-		retCode = "500"
-		w.Write([]byte(retCode))
-		return
-	} else {
-		log.G(Ctx).Info("-- Written configuration")
-	}
-	defer config.Close()
-	log.G(Ctx).Debug("- Setting KUBECONFIG env")
-	err = os.Setenv("KUBECONFIG", path+"config")
-	if err != nil {
-		log.G(Ctx).Error(err)
-		retCode = "500"
-		w.Write([]byte(retCode))
-		return
-	} else {
-		log.G(Ctx).Info("-- Set KUBECONFIG to " + path + "config")
-	}
-
-	kubeconfig, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
-	if err != nil {
-		log.G(Ctx).Error("Unable to create a valid config")
-		return
-	}
-	Clientset, err = kubernetes.NewForConfig(kubeconfig)
-	if err != nil {
-		log.G(Ctx).Fatalln("Unable to set up a clientset")
-	}
-
-	w.Write([]byte(retCode))
 }

--- a/pkg/sidecars/slurm/aux.go
+++ b/pkg/sidecars/slurm/aux.go
@@ -80,7 +80,7 @@ func prepare_mounts(container v1.Container, pod *v1.Pod) []string {
 			if podVolumeSpec != nil && podVolumeSpec.ConfigMap != nil {
 				configMapsPaths, envs := mountConfigMaps(container, pod)
 				for i, path := range configMapsPaths {
-					if strings.Compare(os.Getenv("SHARED_FS"), "true") != 0 {
+					if os.Getenv("SHARED_FS") == "true" {
 						dirs := strings.Split(path, ":")
 						splitDirs := strings.Split(dirs[0], "/")
 						dir := filepath.Join(splitDirs[:len(splitDirs)-1]...)
@@ -92,7 +92,7 @@ func prepare_mounts(container v1.Container, pod *v1.Pod) []string {
 			} else if podVolumeSpec != nil && podVolumeSpec.Secret != nil {
 				secretsPaths, envs := mountSecrets(container, pod)
 				for i, path := range secretsPaths {
-					if strings.Compare(os.Getenv("SHARED_FS"), "true") != 0 {
+					if os.Getenv("SHARED_FS") == "true" {
 						dirs := strings.Split(path, ":")
 						splitDirs := strings.Split(dirs[0], "/")
 						dir := filepath.Join(splitDirs[:len(splitDirs)-1]...)

--- a/pkg/sidecars/slurm/handlers.go
+++ b/pkg/sidecars/slurm/handlers.go
@@ -139,7 +139,6 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	for _, pod := range req.Pods {
 		var flag = false
 		for _, jid := range JID {
-			resp.PodName = append(resp.PodName, commonIL.PodName{Name: string(pod.Name)})
 
 			cmd := []string{"-c", "squeue --me | grep " + jid.JID}
 			shell := exec.ExecTask{
@@ -158,9 +157,9 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if flag {
-			resp.PodStatus = append(resp.PodStatus, commonIL.PodStatus{PodStatus: commonIL.RUNNING})
+			resp.PodStatus = append(resp.PodStatus, commonIL.PodStatus{PodName: string(pod.Name), PodStatus: commonIL.RUNNING})
 		} else {
-			resp.PodStatus = append(resp.PodStatus, commonIL.PodStatus{PodStatus: commonIL.STOP})
+			resp.PodStatus = append(resp.PodStatus, commonIL.PodStatus{PodName: string(pod.Name), PodStatus: commonIL.STOP})
 		}
 	}
 	resp.ReturnVal = "Status"

--- a/pkg/sidecars/slurm/handlers.go
+++ b/pkg/sidecars/slurm/handlers.go
@@ -12,8 +12,6 @@ import (
 	commonIL "github.com/intertwin-eu/interlink/pkg/common"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 var JID []JidStruct
@@ -167,71 +165,4 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, _ = json.Marshal(resp)
 
 	w.Write(bodyBytes)
-}
-
-func SetKubeCFGHandler(w http.ResponseWriter, r *http.Request) {
-	log.G(Ctx).Info("Slurm Sidecar: received SetKubeCFG call")
-	path := "/tmp/.kube/"
-	retCode := "200"
-	bodyBytes, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.G(Ctx).Error(err)
-	}
-
-	var req commonIL.GenericRequestType
-	json.Unmarshal(bodyBytes, &req)
-
-	log.G(Ctx).Debug("- Creating folder to save KubeConfig")
-	err = os.MkdirAll(path, os.ModePerm)
-	if err != nil {
-		log.G(Ctx).Error(err)
-		retCode = "500"
-		w.Write([]byte(retCode))
-		return
-	} else {
-		log.G(Ctx).Debug("-- Created folder")
-	}
-	log.G(Ctx).Debug("- Creating the actual KubeConfig file")
-	config, err := os.Create(path + "config")
-	if err != nil {
-		log.G(Ctx).Error(err)
-		retCode = "500"
-		w.Write([]byte(retCode))
-		return
-	} else {
-		log.G(Ctx).Debug("-- Created file")
-	}
-	log.G(Ctx).Debug("- Writing configuration to file")
-	_, err = config.Write([]byte(req.Body))
-	if err != nil {
-		log.G(Ctx).Error(err)
-		retCode = "500"
-		w.Write([]byte(retCode))
-		return
-	} else {
-		log.G(Ctx).Info("-- Written configuration")
-	}
-	defer config.Close()
-	log.G(Ctx).Debug("- Setting KUBECONFIG env")
-	err = os.Setenv("KUBECONFIG", path+"config")
-	if err != nil {
-		log.G(Ctx).Error(err)
-		retCode = "500"
-		w.Write([]byte(retCode))
-		return
-	} else {
-		log.G(Ctx).Info("-- Set KUBECONFIG to " + path + "config")
-	}
-
-	kubeconfig, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
-	if err != nil {
-		log.G(Ctx).Error("Unable to create a valid config")
-		return
-	}
-	Clientset, err = kubernetes.NewForConfig(kubeconfig)
-	if err != nil {
-		log.G(Ctx).Fatalln("Unable to set up a clientset")
-	}
-
-	w.Write([]byte(retCode))
 }

--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -18,10 +18,10 @@ import (
 
 var NoReq uint8
 
-func createRequest(pod commonIL.Request, token string) ([]byte, error) {
+func createRequest(pods []*v1.Pod, token string) ([]byte, error) {
 	var returnValue, _ = json.Marshal(commonIL.PodStatus{PodStatus: commonIL.UNKNOWN})
 
-	bodyBytes, err := json.Marshal(pod)
+	bodyBytes, err := json.Marshal(pods)
 	if err != nil {
 		log.L.Error(err)
 		return nil, err
@@ -49,10 +49,10 @@ func createRequest(pod commonIL.Request, token string) ([]byte, error) {
 	return returnValue, nil
 }
 
-func deleteRequest(pod commonIL.Request, token string) ([]byte, error) {
+func deleteRequest(pods []*v1.Pod, token string) ([]byte, error) {
 	var returnValue, _ = json.Marshal(commonIL.PodStatus{PodStatus: commonIL.UNKNOWN})
 
-	bodyBytes, err := json.Marshal(pod)
+	bodyBytes, err := json.Marshal(pods)
 	if err != nil {
 		log.L.Error(err)
 		return nil, err
@@ -82,7 +82,7 @@ func deleteRequest(pod commonIL.Request, token string) ([]byte, error) {
 	return returnValue, nil
 }
 
-func statusRequest(podsList commonIL.Request, token string) ([]byte, error) {
+func statusRequest(podsList []*v1.Pod, token string) ([]byte, error) {
 	var returnValue []byte
 
 	bodyBytes, err := json.Marshal(podsList)
@@ -117,8 +117,8 @@ func statusRequest(podsList commonIL.Request, token string) ([]byte, error) {
 }
 
 func RemoteExecution(p *VirtualKubeletProvider, ctx context.Context, mode int8, imageLocation string, pod *v1.Pod, container v1.Container) error {
-	var req commonIL.Request
-	req.Pods = map[string]*v1.Pod{pod.Name: pod}
+	var req []*v1.Pod
+	req = []*v1.Pod{pod}
 
 	b, err := os.ReadFile(commonIL.InterLinkConfigInst.VKTokenFile) // just pass the file name
 	if err != nil {
@@ -159,8 +159,11 @@ func checkPodsStatus(p *VirtualKubeletProvider, ctx context.Context, token strin
 	}
 	var returnVal []byte
 	var ret commonIL.StatusResponse
-	var PodsList commonIL.Request
-	PodsList.Pods = p.pods
+	var PodsList []*v1.Pod
+
+	for _, pod := range p.pods {
+		PodsList = append(PodsList, pod)
+	}
 	log.G(ctx).Info(p.pods)
 
 	returnVal, err := statusRequest(PodsList, token)

--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -141,8 +141,8 @@ func NewProviderConfig(config VirtualKubeletConfig, nodeName, operatingSystem st
 }
 
 // NewProvider creates a new Provider, which implements the PodNotifier interface
-func NewProvider(providerConfig, nodeName, operatingSystem string, internalIP string, daemonEndpointPort int32) (*VirtualKubeletProvider, error) {
-	config, err := loadConfig(providerConfig, nodeName)
+func NewProvider(providerConfig, nodeName, operatingSystem string, internalIP string, daemonEndpointPort int32, ctx context.Context) (*VirtualKubeletProvider, error) {
+	config, err := loadConfig(providerConfig, nodeName, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -150,10 +150,14 @@ func NewProvider(providerConfig, nodeName, operatingSystem string, internalIP st
 }
 
 // loadConfig loads the given json configuration files and yaml to communicate with InterLink.
-func loadConfig(providerConfig, nodeName string) (config VirtualKubeletConfig, err error) {
+func loadConfig(providerConfig, nodeName string, ctx context.Context) (config VirtualKubeletConfig, err error) {
 
 	commonIL.NewInterLinkConfig()
-	commonIL.NewServiceAccount()
+	err = commonIL.NewServiceAccount()
+
+	if err != nil {
+		log.G(ctx).Fatal(err)
+	}
 
 	data, err := ioutil.ReadFile(providerConfig)
 	if err != nil {


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Reworked Docker plugin to be totally independent from Kubernetes and Kubectl. InterLink now retrieves Secrets/ConfigMaps/EmptyDirs and sends them through a REST call to the Plugin (that's the reason behind a slightly rework in common types too: only 1 Create call, but with bigger JSON received, to store all the needed data).

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
Slurm Plugin still needs to be reworked to be fully working, but it's on its way