### PR TITLE
Adapt Interlink to handle HTCondor sidecar

### DIFF
--- a/pkg/common/func.go
+++ b/pkg/common/func.go
@@ -72,8 +72,11 @@ func NewInterLinkConfig() {
 			case "slurm":
 				InterLinkConfigInst.Sidecarport = "4001"
 
+			case "htcondor":
+				InterLinkConfigInst.Sidecarport = "8000"
+
 			default:
-				fmt.Println("Define in InterLinkConfig.yaml one service between docker and slurm")
+				fmt.Println("Define in InterLinkConfig.yaml one service between docker, htcondor and slurm")
 				os.Exit(-1)
 			}
 		}

--- a/pkg/common/func.go
+++ b/pkg/common/func.go
@@ -51,13 +51,13 @@ func NewInterLinkConfig() {
 		}
 
 		if os.Getenv("SIDECARSERVICE") != "" {
-			if os.Getenv("SIDECARSERVICE") != "docker" && os.Getenv("SIDECARSERVICE") != "slurm" {
-				fmt.Println("export SIDECARSERVICE as docker or slurm")
+			if os.Getenv("SIDECARSERVICE") != "docker" && os.Getenv("SIDECARSERVICE") != "slurm" &&  os.Getenv("SIDECARSERVICE") != "htcondor" {                               
+				fmt.Println("export SIDECARSERVICE as docker or slurm or htcondor")
 				os.Exit(-1)
 			}
 			InterLinkConfigInst.Sidecarservice = os.Getenv("SIDECARSERVICE")
-		} else if InterLinkConfigInst.Sidecarservice != "docker" && InterLinkConfigInst.Sidecarservice != "slurm" {
-			fmt.Println("Set \"docker\" or \"slurm\" in config file or export SIDECARSERVICE as ENV")
+		} else if InterLinkConfigInst.Sidecarservice != "docker" && InterLinkConfigInst.Sidecarservice != "slurm" && InterLinkConfigInst.Sidecarservice != "htcondor" {
+			fmt.Println("Set \"docker\", \"htcondor\" or \"slurm\" in config file or export SIDECARSERVICE as ENV")
 			os.Exit(-1)
 		}
 

--- a/pkg/interlink/create.go
+++ b/pkg/interlink/create.go
@@ -53,7 +53,10 @@ func CreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	case "slurm":
 		req, err = http.NewRequest(http.MethodPost, commonIL.InterLinkConfigInst.Sidecarurl+":"+commonIL.InterLinkConfigInst.Sidecarport+"/submit", reader)
-
+		
+	case "htcondor":
+		req, err = http.NewRequest(http.MethodPost, commonIL.InterLinkConfigInst.Sidecarurl+":"+commonIL.InterLinkConfigInst.Sidecarport+"/submit", reader)
+	
 	default:
 		break
 	}

--- a/pkg/interlink/delete.go
+++ b/pkg/interlink/delete.go
@@ -27,6 +27,8 @@ func DeleteHandler(w http.ResponseWriter, r *http.Request) {
 	case "slurm":
 		req, err = http.NewRequest(http.MethodPost, commonIL.InterLinkConfigInst.Sidecarurl+":"+commonIL.InterLinkConfigInst.Sidecarport+"/stop", reader)
 
+	case "htcondor":
+		req, err = http.NewRequest(http.MethodPost, commonIL.InterLinkConfigInst.Sidecarurl+":"+commonIL.InterLinkConfigInst.Sidecarport+"/stop", reader)
 	default:
 		break
 	}


### PR DESCRIPTION
This PR adapts Interlink in order to handle also the HTCondor sidecar with its default port and proper calls
