### PR TITLE
Added mutex to avoid concurrent map writing

### DIFF
--- a/pkg/sidecars/slurm/Delete.go
+++ b/pkg/sidecars/slurm/Delete.go
@@ -36,7 +36,7 @@ func (h *SidecarHandler) StopHandler(w http.ResponseWriter, r *http.Request) {
 
 	filesPath := h.Config.DataRootFolder + pod.Namespace + "-" + string(pod.UID)
 
-	err = deleteContainer(h.Ctx, h.Config, string(pod.UID), h.JIDs, filesPath+"/"+pod.Namespace)
+	err = deleteContainer(h.Ctx, h.Config, h.Mutex, string(pod.UID), h.JIDs, filesPath+"/"+pod.Namespace)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
 		w.WriteHeader(statusCode)


### PR DESCRIPTION
…RM sidecar

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

As stated in the issue #179, it is possible to have concurrent map writing, since maps are not meant for concurrent write access. Added a Mutex to avoid it

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#179