### PR TITLE
Prepending Job Output

### DIFF
--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func main() {
 	kubecfgFile, err := os.ReadFile(os.Getenv("KUBECONFIG"))
 	if err != nil {
 		if os.Getenv("KUBECONFIG") != "" {
-			log.G(ctx).Error(err)
+			log.G(ctx).Debug(err)
 		}
 		log.G(ctx).Info("Trying InCluster configuration")
 


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

On the SLURM sidecar, only the container output was returned before. Now even the Job output is.

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#187