### PR TITLE
Stateless vk

### DIFF
--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -186,7 +186,7 @@ func main() {
 	}
 	log.L = logruslogger.FromLogrus(logrus.NewEntry(logger))
 
-	/*shutdown, err := initProvider()
+	shutdown, err := initProvider()
 	if err != nil {
 		log.G(ctx).Fatal(err)
 	}
@@ -194,7 +194,7 @@ func main() {
 		if err := shutdown(ctx); err != nil {
 			log.G(ctx).Fatal("failed to shutdown TracerProvider: %w", err)
 		}
-	}()*/
+	}()
 
 	log.G(ctx).Info("Tracer setup succeeded")
 

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -169,6 +169,7 @@ func main() {
 	defer cancel()
 	nodename := flag.String("nodename", "", "The name of the node")
 	configpath := flag.String("configpath", "", "Path to the VK config")
+	flag.Parse()
 	interLinkConfig, err := commonIL.LoadConfig(*configpath, *nodename, ctx)
 	if err != nil {
 		panic(err)
@@ -185,7 +186,7 @@ func main() {
 	}
 	log.L = logruslogger.FromLogrus(logrus.NewEntry(logger))
 
-	shutdown, err := initProvider()
+	/*shutdown, err := initProvider()
 	if err != nil {
 		log.G(ctx).Fatal(err)
 	}
@@ -193,7 +194,7 @@ func main() {
 		if err := shutdown(ctx); err != nil {
 			log.G(ctx).Fatal("failed to shutdown TracerProvider: %w", err)
 		}
-	}()
+	}()*/
 
 	log.G(ctx).Info("Tracer setup succeeded")
 

--- a/pkg/interlink/api/status.go
+++ b/pkg/interlink/api/status.go
@@ -91,15 +91,21 @@ func (h *InterLinkHandler) StatusHandler(w http.ResponseWriter, r *http.Request)
 
 	}
 
-	for _, pod := range pods {
-		PodStatuses.mu.Lock()
-		for _, cached := range PodStatuses.Statuses {
-			if cached.PodUID == string(pod.UID) {
-				returnPods = append(returnPods, cached)
-				break
+	if len(pods) > 0 {
+		for _, pod := range pods {
+			PodStatuses.mu.Lock()
+			for _, cached := range PodStatuses.Statuses {
+				if cached.PodUID == string(pod.UID) {
+					returnPods = append(returnPods, cached)
+					break
+				}
 			}
+			PodStatuses.mu.Unlock()
 		}
-		PodStatuses.mu.Unlock()
+	} else {
+		for _, pod := range PodStatuses.Statuses {
+			returnPods = append(returnPods, pod)
+		}
 	}
 
 	returnValue, err := json.Marshal(returnPods)


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

When VK starts up, it now queries InterLink API to retrieve all cached Pods to add them back to its list of known Pods. This is important to avoid Pod recreation and to not lose track of already submitted Jobs. Soon, a InterLink API update will follow to implement a similar mechanism to query the below plugin in case of API failure, to keep track of running jobs.

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#195