### PR TITLE
Reworked API for interLink stability over restarts

### DIFF
--- a/pkg/interlink/types.go
+++ b/pkg/interlink/types.go
@@ -18,6 +18,7 @@ type PodStatus struct {
 	PodName      string               `json:"name"`
 	PodUID       string               `json:"UID"`
 	PodNamespace string               `json:"namespace"`
+	JobID        string               `json:"JID"`
 	Containers   []v1.ContainerStatus `json:"containers"`
 }
 
@@ -53,4 +54,9 @@ type LogStruct struct {
 	PodName       string           `json:"PodName"`
 	ContainerName string           `json:"ContainerName"`
 	Opts          ContainerLogOpts `json:"Opts"`
+}
+
+type CreateStruct struct {
+	PodUID string `json:"PodUID"`
+	PodJID string `json:"PodJID"`
 }

--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -694,7 +694,7 @@ func (p *VirtualKubeletProvider) GetStatsSummary(ctx context.Context) (*stats.Su
 	return res, nil
 }
 
-// GetPods returns a list of all pods known to be "running".
+// RetrievePodsFromCluster scans all pods registered to the K8S cluster and re-assigns the ones with a valid JobID to the Virtual Kubelet.
 func (p *VirtualKubeletProvider) RetrievePodsFromInterlink(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "RetrievePodsFromInterlink")
 	defer span.End()


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Slightly changed the Create. If before it just returned a string, it now returns a new struct defined in types.go consisting of a Pod UID and a Job ID, so that it is now possible to directly bind a pod to a specific job. It is an Annotation in the pod struct, specifically pod.Annotations["JobID"].

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#205 #206 