### PR TITLE
Init containers now retrieved

### DIFF
--- a/pkg/interlink/api/create.go
+++ b/pkg/interlink/api/create.go
@@ -60,7 +60,6 @@ func (h *InterLinkHandler) CreateHandler(w http.ResponseWriter, r *http.Request)
 		log.G(h.Ctx).Debug(string(bodyBytes))
 		reader := bytes.NewReader(bodyBytes)
 
-		log.G(h.Ctx).Info(req)
 		req, err = http.NewRequest(http.MethodPost, h.Config.Sidecarurl+":"+h.Config.Sidecarport+"/create", reader)
 
 		if err != nil {

--- a/pkg/interlink/api/func.go
+++ b/pkg/interlink/api/func.go
@@ -25,6 +25,17 @@ func getData(ctx context.Context, config commonIL.InterLinkConfig, pod commonIL.
 	log.G(ctx).Debug(pod.ConfigMaps)
 	var retrievedData commonIL.RetrievedPodData
 	retrievedData.Pod = pod.Pod
+	for _, container := range pod.Pod.Spec.InitContainers {
+		log.G(ctx).Info("- Retrieving Secrets and ConfigMaps for the Docker Sidecar. InitContainer: " + container.Name)
+		log.G(ctx).Debug(container.VolumeMounts)
+		data, err := retrieveData(ctx, config, pod, container)
+		if err != nil {
+			log.G(ctx).Error(err)
+			return commonIL.RetrievedPodData{}, err
+		}
+		retrievedData.Containers = append(retrievedData.Containers, data)
+	}
+
 	for _, container := range pod.Pod.Spec.Containers {
 		log.G(ctx).Info("- Retrieving Secrets and ConfigMaps for the Docker Sidecar. Container: " + container.Name)
 		log.G(ctx).Debug(container.VolumeMounts)


### PR DESCRIPTION

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Init containers were ignored. Now they are retrieved by InterLink and passed in the same identical way to the sidecar, but before "normal" containers

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#220