### PR TITLE
initContainers now retrieved

### DIFF
--- a/pkg/interlink/api/func.go
+++ b/pkg/interlink/api/func.go
@@ -25,6 +25,18 @@ func getData(ctx context.Context, config commonIL.InterLinkConfig, pod commonIL.
 	log.G(ctx).Debug(pod.ConfigMaps)
 	var retrievedData commonIL.RetrievedPodData
 	retrievedData.Pod = pod.Pod
+
+	for _, container := range pod.Pod.Spec.InitContainers {
+		log.G(ctx).Info("- Retrieving Secrets and ConfigMaps for the Docker Sidecar. InitContainer: " + container.Name)
+		log.G(ctx).Debug(container.VolumeMounts)
+		data, err := retrieveData(ctx, config, pod, container)
+		if err != nil {
+			log.G(ctx).Error(err)
+			return commonIL.RetrievedPodData{}, err
+		}
+		retrievedData.Containers = append(retrievedData.Containers, data)
+	}
+
 	for _, container := range pod.Pod.Spec.Containers {
 		log.G(ctx).Info("- Retrieving Secrets and ConfigMaps for the Docker Sidecar. Container: " + container.Name)
 		log.G(ctx).Debug(container.VolumeMounts)


### PR DESCRIPTION
…other containers in the array)

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Init containers were ignored. Now they are retrieved by InterLink and passed in the same identical way to the sidecar, but before "normal" containers

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#220