### PR TITLE
Patches after 0.3.0 rc revies

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,8 @@ builds:
     main: ./cmd/virtual-kubelet
   - id: "interlink"
     binary: interlink
+    hooks:
+      pre: bash -c "KUBELET_VERSION={{.Version}} ./cmd/virtual-kubelet/set-version.sh" 
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/installer/templates/deployment.yaml
+++ b/cmd/installer/templates/deployment.yaml
@@ -15,10 +15,10 @@ spec:
       labels:
         nodeName: {{.VKName}}
     spec:
-      #hostNetwork: true
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8 
       containers:
-      - name: jaeger
-        image: jaegertracing/all-in-one:1.51
       - name: inttw-vk
         image: ghcr.io/intertwin-eu/interlink/virtual-kubelet-inttw:{{.InterLinkVersion}}
         imagePullPolicy: Always
@@ -54,7 +54,6 @@ spec:
         env:
         - name: IAM_TOKEN_ENDPOINT 
           value: {{.OAUTH.TokenURL}} 
-        # TODO load env IAM client from secret
         - name: IAM_CLIENT_ID
           value: {{.OAUTH.ClientID}}
         - name: IAM_CLIENT_SECRET
@@ -87,6 +86,4 @@ spec:
           # Provide the name of the ConfigMap you want to mount.
           name: {{.VKName}}-config
       - name: token
-        hostPath:
-          path: /tmp
-          type: Directory
+        emptyDir: {}

--- a/cmd/interlink/main.go
+++ b/cmd/interlink/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"flag"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -9,15 +11,23 @@ import (
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	logruslogger "github.com/virtual-kubelet/virtual-kubelet/log/logrus"
 
-	commonIL "github.com/intertwin-eu/interlink/pkg/interlink"
+	types "github.com/intertwin-eu/interlink/pkg/interlink"
 	"github.com/intertwin-eu/interlink/pkg/interlink/api"
+	"github.com/intertwin-eu/interlink/pkg/virtualkubelet"
 )
 
 func main() {
-	var cancel context.CancelFunc
-	api.PodStatuses.Statuses = make(map[string]commonIL.PodStatus)
+	printVersion := flag.Bool("version", false, "show version")
+	flag.Parse()
 
-	interLinkConfig, err := commonIL.NewInterLinkConfig()
+	if *printVersion {
+		fmt.Println(virtualkubelet.KubeletVersion)
+		return
+	}
+	var cancel context.CancelFunc
+	api.PodStatuses.Statuses = make(map[string]types.PodStatus)
+
+	interLinkConfig, err := types.NewInterLinkConfig()
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/interlink/main.go
+++ b/cmd/interlink/main.go
@@ -46,6 +46,8 @@ func main() {
 
 	log.G(ctx).Info(interLinkConfig)
 
+	log.G(ctx).Info("interLink version: ", virtualkubelet.KubeletVersion)
+
 	sidecarEndpoint := ""
 	if strings.HasPrefix(interLinkConfig.Sidecarurl, "unix://") {
 		sidecarEndpoint = interLinkConfig.Sidecarurl

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -115,7 +115,14 @@ func initProvider() (func(context.Context) error, error) {
 	// probably connect directly to the service through dns.
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, "localhost:4317",
+
+	otlpEndpoint := os.Getenv("TELEMETRY_ENDPOINT")
+
+	if otlpEndpoint == "" {
+		otlpEndpoint = "localhost:4317"
+	}
+
+	conn, err := grpc.DialContext(ctx, otlpEndpoint,
 		// Note the use of insecure transport here. TLS is recommended in production.
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),

--- a/docker/Dockerfile.interlink
+++ b/docker/Dockerfile.interlink
@@ -10,6 +10,8 @@ ENV GOCACHE="/go/build-cache"
 
 RUN mkdir -p $GOMODCACHE && mkdir -p $GOCACHE
 
+ARG VERSION
+RUN bash -c "KUBELET_VERSION=${VERSION} ./cmd/virtual-kubelet/set-version.sh"
 
 RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/interlink cmd/interlink/main.go

--- a/pkg/interlink/api/create.go
+++ b/pkg/interlink/api/create.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/containerd/containerd/log"
 
-	commonIL "github.com/intertwin-eu/interlink/pkg/interlink"
+	types "github.com/intertwin-eu/interlink/pkg/interlink"
 )
 
 // CreateHandler collects and rearranges all needed ConfigMaps/Secrets/EmptyDirs to ship them to the sidecar, then sends a response to the client
@@ -25,8 +25,8 @@ func (h *InterLinkHandler) CreateHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	var req *http.Request              //request to forward to sidecar
-	var pod commonIL.PodCreateRequests //request for interlink
+	var req *http.Request           //request to forward to sidecar
+	var pod types.PodCreateRequests //request for interlink
 	err = json.Unmarshal(bodyBytes, &pod)
 	if err != nil {
 		statusCode = http.StatusInternalServerError
@@ -35,9 +35,9 @@ func (h *InterLinkHandler) CreateHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	var retrievedData []commonIL.RetrievedPodData
+	var retrievedData []types.RetrievedPodData
 
-	data := commonIL.RetrievedPodData{}
+	data := types.RetrievedPodData{}
 	if h.Config.ExportPodData {
 		data, err = getData(h.Ctx, h.Config, pod)
 		if err != nil {

--- a/pkg/interlink/api/delete.go
+++ b/pkg/interlink/api/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containerd/containerd/log"
 	v1 "k8s.io/api/core/v1"
 
-	commonIL "github.com/intertwin-eu/interlink/pkg/interlink"
+	types "github.com/intertwin-eu/interlink/pkg/interlink"
 )
 
 // DeleteHandler deletes the cached status for the provided Pod and forwards the request to the sidecar
@@ -64,8 +64,8 @@ func (h *InterLinkHandler) DeleteHandler(w http.ResponseWriter, r *http.Request)
 		w.WriteHeader(http.StatusOK)
 	}
 	log.G(h.Ctx).Debug("InterLink: " + string(returnValue))
-	var returnJson []commonIL.PodStatus
-	returnJson = append(returnJson, commonIL.PodStatus{PodName: pod.Name, PodUID: string(pod.UID), PodNamespace: pod.Namespace})
+	var returnJson []types.PodStatus
+	returnJson = append(returnJson, types.PodStatus{PodName: pod.Name, PodUID: string(pod.UID), PodNamespace: pod.Namespace})
 
 	bodyBytes, err = json.Marshal(returnJson)
 	if err != nil {

--- a/pkg/interlink/api/logs.go
+++ b/pkg/interlink/api/logs.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/containerd/containerd/log"
 
-	commonIL "github.com/intertwin-eu/interlink/pkg/interlink"
+	types "github.com/intertwin-eu/interlink/pkg/interlink"
 )
 
 func (h *InterLinkHandler) GetLogsHandler(w http.ResponseWriter, r *http.Request) {
@@ -22,7 +22,7 @@ func (h *InterLinkHandler) GetLogsHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	log.G(h.Ctx).Info("InterLink: unmarshal GetLogs request")
-	var req2 commonIL.LogStruct //incoming request. To be used in interlink API. req is directly forwarded to sidecar
+	var req2 types.LogStruct //incoming request. To be used in interlink API. req is directly forwarded to sidecar
 	err = json.Unmarshal(bodyBytes, &req2)
 	if err != nil {
 		statusCode = http.StatusInternalServerError

--- a/pkg/interlink/api/status.go
+++ b/pkg/interlink/api/status.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containerd/containerd/log"
 	v1 "k8s.io/api/core/v1"
 
-	commonIL "github.com/intertwin-eu/interlink/pkg/interlink"
+	types "github.com/intertwin-eu/interlink/pkg/interlink"
 )
 
 func (h *InterLinkHandler) StatusHandler(w http.ResponseWriter, r *http.Request) {
@@ -29,8 +29,8 @@ func (h *InterLinkHandler) StatusHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	var podsToBeChecked []*v1.Pod
-	var returnedStatuses []commonIL.PodStatus //returned from the query to the sidecar
-	var returnPods []commonIL.PodStatus       //returned to the vk
+	var returnedStatuses []types.PodStatus //returned from the query to the sidecar
+	var returnPods []types.PodStatus       //returned to the vk
 
 	PodStatuses.mu.Lock()
 	for _, pod := range pods {

--- a/pkg/virtualkubelet/config.go
+++ b/pkg/virtualkubelet/config.go
@@ -2,7 +2,7 @@ package virtualkubelet
 
 // VirtualKubeletConfig holds the whole configuration
 type VirtualKubeletConfig struct {
-	Interlinkurl      string `yaml:"InterlinkURL"`
+	InterlinkURL      string `yaml:"InterlinkURL"`
 	Interlinkport     string `yaml:"InterlinkPort"`
 	VKConfigPath      string `yaml:"VKConfigPath"`
 	VKTokenFile       string `yaml:"VKTokenFile"`
@@ -11,8 +11,8 @@ type VirtualKubeletConfig struct {
 	PodIP             string `yaml:"PodIP"`
 	VerboseLogging    bool   `yaml:"VerboseLogging"`
 	ErrorsOnlyLogging bool   `yaml:"ErrorsOnlyLogging"`
-	CPU               string `yaml:"cpu,omitempty"`
-	Memory            string `yaml:"memory,omitempty"`
-	Pods              string `yaml:"pods,omitempty"`
+	CPU               string `yaml:"CPU,omitempty"`
+	Memory            string `yaml:"Memory,omitempty"`
+	Pods              string `yaml:"Pods,omitempty"`
 	GPU               string `yaml:"nvidia.com/gpu,omitempty"`
 }

--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -621,7 +621,7 @@ func nodeConditions() []v1.NodeCondition {
 	return []v1.NodeCondition{
 		{
 			Type:               "Ready",
-			Status:             v1.ConditionTrue,
+			Status:             v1.ConditionFalse,
 			LastHeartbeatTime:  metav1.Now(),
 			LastTransitionTime: metav1.Now(),
 			Reason:             "KubeletPending",
@@ -653,7 +653,7 @@ func nodeConditions() []v1.NodeCondition {
 		},
 		{
 			Type:               "NetworkUnavailable",
-			Status:             v1.ConditionFalse,
+			Status:             v1.ConditionTrue,
 			LastHeartbeatTime:  metav1.Now(),
 			LastTransitionTime: metav1.Now(),
 			Reason:             "RouteCreated",

--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	commonIL "github.com/intertwin-eu/interlink/pkg/interlink"
+	types "github.com/intertwin-eu/interlink/pkg/interlink"
 )
 
 const (
@@ -756,12 +756,12 @@ func (p *VirtualKubeletProvider) GetLogs(ctx context.Context, namespace, podName
 		log.G(ctx).Error(err)
 	}
 
-	logsRequest := commonIL.LogStruct{
+	logsRequest := types.LogStruct{
 		Namespace:     namespace,
 		PodUID:        string(p.pods[key].UID),
 		PodName:       podName,
 		ContainerName: containerName,
-		Opts:          commonIL.ContainerLogOpts(opts),
+		Opts:          types.ContainerLogOpts(opts),
 	}
 
 	return LogRetrieval(ctx, p.config, logsRequest)


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

- Enhance debug information for status report
- print version of the interlink binary
- vk node is now starting in notReady, not allowing pending pod to be polled unless the remote side is OK
- telemetry endpoint is now configurable
- CPU and memory allocatable resources are now taken correctly from the config file

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
