### PR TITLE
Starting vk secret informers at bootstrap #263

### DIFF
--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -308,6 +308,9 @@ func main() {
 		resync,
 	)
 
+	scmInformer := scmInformerFactory.Core().V1().Secrets().Informer()
+	podInformer := podInformerFactory.Core().V1().Secrets().Informer()
+
 	podControllerConfig := node.PodControllerConfig{
 		PodClient:         localClient.CoreV1(),
 		Provider:          nodeProvider,
@@ -325,6 +328,8 @@ func main() {
 	// start informers ->
 	go podInformerFactory.Start(stopper)
 	go scmInformerFactory.Start(stopper)
+	go scmInformer.Run(stopper)
+	go podInformer.Run(stopper)
 
 	// start to sync and call list
 	if !cache.WaitForCacheSync(stopper, podInformerFactory.Core().V1().Pods().Informer().HasSynced) {


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Pod and Secrets/configmaps informers weren't starting because only Informers' factory was created and run. Now they are both created using factories and started

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#263