### PR TITLE
Splitting GitHub Actions

### DIFF
--- a/.github/workflows/build_docusaurus.yaml
+++ b/.github/workflows/build_docusaurus.yaml
@@ -1,0 +1,50 @@
+name: Update Docusaurus
+
+on:
+  push:
+    branches:
+      -  main
+    tags-ignore:
+      - "*"
+  workflow_call:
+
+jobs:
+  update-doc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Remove existing openapi.json
+        run: rm ./docs/openapi/openapi.json
+
+      - name: Download openapi.json
+        uses: robinraju/release-downloader@v1
+        with:
+          latest: true
+          preRelease: false
+          fileName: 'openAPISpec'
+          out-file-path: 'docs/openapi'
+      
+      - name: Rename openAPISpec to openapi.json
+        run: mv ./docs/openapi/openAPISpec ./docs/openapi/openapi.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'  # Ensure this matches the Node.js version required by Docusaurus
+
+      - name: Install dependencies
+        working-directory: ./docs  # Change to the directory where package.json is located
+        run: npm install
+
+      - name: Build Docusaurus site
+        working-directory: ./docs  # Change to the directory where package.json is located
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build   # Ensure this matches the build output directory of Docusaurus#

--- a/.github/workflows/build_openapi.yaml
+++ b/.github/workflows/build_openapi.yaml
@@ -26,11 +26,6 @@ jobs:
     - name: Run script to generate OpenAPI JSON
       run: python example/create_openapi.py
 
-    - name: Upload OpenAPI JSON as an artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: openapi.json
-        path: ./docs/openapi/openapi.json
     - name: Upload json to release
       uses: svenstaro/upload-release-action@v2
       with:
@@ -40,40 +35,6 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
         body: "OpenAPI spec for plugin REST" 
-  
-  update-doc:
-    needs: update-openapi
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: |
-        rm ./docs/openapi/openapi.json
-
-    - name: Download artifact from the latest workflow run
-      uses: actions/download-artifact@v4
-      with:
-        name: openapi.json  # Name of the artifact you want to download
-        path: ./docs/openapi  # Directory where the artifact will be downloaded
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '22'  # Ensure this matches the Node.js version required by Docusaurus
-
-    - name: Install dependencies
-      working-directory: ./docs  # Change to the directory where package.json is located
-      run: npm install
-
-    - name: Build Docusaurus site
-      working-directory: ./docs  # Change to the directory where package.json is located
-      run: npm run build
-
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/build   # Ensure this matches the build output directory of Docusaurus
+    
+  Trigger-Docusaurus-Update:
+    uses: ./.github/workflows/build_docusaurus.yaml


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Before, there was a GitHub Action performing both the build of the OpenAPI Spec file and the Documentation update; it was triggered by pushing a tag, but this wasn't optimal.
Now the Action has been split in 2 parts:
- The Update Docusaurus Action is run every time a commit is pushed to the *main* branch; it is not directly executed for tags being pushed, but it is called by the Update OpenAPI Action.
- The Update OpenAPI Action is called only when a new tag is pushed and it calls the Update Docusaurus Action after performing all the previous necessary steps to be sure to have correctly generated (and uploaded among release files) the fresh new OpenAPISpec file

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
