### PR TITLE
add: aliases for camelCase support + container ports definition

### DIFF
--- a/example/interlink/spec.py
+++ b/example/interlink/spec.py
@@ -1,7 +1,7 @@
 import datetime
-from typing import Dict, List, Optional
+from typing import Annotated, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class Metadata(BaseModel):
     name: Optional[str] = None
@@ -9,15 +9,17 @@ class Metadata(BaseModel):
     uid: Optional[str] = None
     annotations: Optional[Dict[str, str]] = Field({})
     labels: Optional[Dict[str, str]] = Field({})
-    generate_name: Optional[str] = None
+    generate_name: Annotated[str | None, Field(alias="generateName")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class VolumeMount(BaseModel):
     name: str
-    mount_path: str
-    sub_path: Optional[str] = None
-    read_only: Optional[bool] = False
-    mount_propagation: Optional[str] = None
+    mount_path: Annotated[str, Field(alias="mountPath")]
+    sub_path: Annotated[str | None, Field(alias="subPath")] = None
+    read_only: Annotated[bool | None, Field(alias="readOnly")] = False
+    mount_propagation: Annotated[str | None, Field(alias="mountPropagation")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class ConfigMapKeySelector(BaseModel):
@@ -33,24 +35,36 @@ class SecretKeySelector(BaseModel):
 
 
 class EnvVarSource(BaseModel):
-    config_map_key_ref: Optional[ConfigMapKeySelector] = None
-    secret_key_ref: Optional[SecretKeySelector] = None
+    config_map_key_ref: Annotated[ConfigMapKeySelector | None, Field(alias="configMapKeyRef")] = None
+    secret_key_ref: Annotated[SecretKeySelector | None, Field(alias="secretKeyRef")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class EnvVar(BaseModel):
     name: str
     value: Optional[str] = None
-    value_from: Optional[EnvVarSource] = None
+    value_from: Annotated[EnvVarSource | None, Field(alias="valueFrom")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class SecurityContext(BaseModel):
-    allow_privilege_escalation: Optional[bool] = None
+    allow_privilege_escalation: Annotated[bool | None, Field(alias="allowPrivilegeEscalation")] = None
     privileged: Optional[bool] = None
-    proc_mount: Optional[str] = None
-    read_only_file_system: Optional[bool] = None
-    run_as_group: Optional[int] = None
-    run_as_non_root: Optional[bool] = None
-    run_as_user: Optional[int] = None
+    proc_mount: Annotated[str | None, Field(alias="procMount")] = None
+    read_only_file_system: Annotated[bool | None, Field(alias="readOnlyFileSystem")] = None
+    run_as_group: Annotated[int | None, Field(alias="runAsGroup")] = None
+    run_as_non_root: Annotated[bool | None, Field(alias="runAsNonRoot")] = None
+    run_as_user: Annotated[int | None, Field(alias="runAsUser")] = None
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ContainerPort(BaseModel):
+    container_port: Annotated[int, Field(alias="containerPort")]
+    host_ip: Annotated[str | None, Field(alias="hostIp")] = None
+    host_port: Annotated[int | None, Field(alias="hostPort")] = None
+    name: Optional[str] = None
+    protocol: Optional[str] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class Container(BaseModel):
@@ -60,9 +74,11 @@ class Container(BaseModel):
     command: List[str]
     args: Optional[List[str]] = Field([])
     resources: Optional[dict] = Field({})
-    volume_mounts: Optional[List[VolumeMount]] = Field([])
+    volume_mounts: Annotated[List[VolumeMount] | None, Field(alias="volumeMounts")] = []
     env: Optional[List[EnvVar]] = None
-    security_context: Optional[SecurityContext] = None
+    security_context: Annotated[SecurityContext | None, Field(alias="securityContext")] = None
+    ports: Optional[List[ContainerPort]] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class KeyToPath(BaseModel):
@@ -72,17 +88,19 @@ class KeyToPath(BaseModel):
 
 
 class SecretVolumeSource(BaseModel):
-    secret_name: str
+    secret_name: Annotated[str, Field(alias="secretName")]
     items: Optional[List[KeyToPath]] = Field([])
     optional: Optional[bool] = None
-    default_mode: Optional[int] = None
+    default_mode: Annotated[int | None, Field(alias="defaultMode")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class ConfigMapVolumeSource(BaseModel):
     name: str
     items: Optional[List[KeyToPath]] = Field([])
     optional: Optional[bool] = None
-    default_mode: Optional[int] = None
+    default_mode: Annotated[int | None, Field(alias="defaultMode")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 # class VolumeSource(BaseModel):
@@ -94,20 +112,22 @@ class ConfigMapVolumeSource(BaseModel):
 class PodVolume(BaseModel):
     name: str
     #    volumeSource: Optional[VolumeSource] = None
-    empty_dir: Optional[dict] = None
+    empty_dir: Annotated[dict | None, Field(alias="emptyDir")] = None
     secret: Optional[SecretVolumeSource] = None
-    config_map: Optional[ConfigMapVolumeSource] = None
+    config_map: Annotated[ConfigMapVolumeSource | None, Field(alias="configMap")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class PodSpec(BaseModel):
     containers: List[Container]
-    init_containers: Optional[List[Container]] = None
+    init_containers: Annotated[List[Container] | None, Field(alias="initContainers")] = None
     volumes: Optional[List[PodVolume]] = None
-    preemption_policy: Optional[str] = None
-    priority_class_name: Optional[str] = None
+    preemption_policy: Annotated[str | None, Field(alias="preemptionPolicy")] = None
+    priority_class_name: Annotated[str | None, Field(alias="priorityClassName")] = None
     priority: Optional[int] = None
-    restart_policy: Optional[str] = None
-    termination_grace_period_seconds: Optional[int] = None
+    restart_policy: Annotated[str | None, Field(alias="restartPolicy")] = None
+    termination_grace_period_seconds: Annotated[int | None, Field(alias="terminationGracePeriodSeconds")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class PodRequest(BaseModel):
@@ -118,24 +138,27 @@ class PodRequest(BaseModel):
 class ConfigMap(BaseModel):
     metadata: Metadata
     data: Optional[dict]
-    binary_data: Optional[dict] = None
+    binary_data: Annotated[dict | None, Field(alias="binaryData")] = None
     type: Optional[str] = None
     immutable: Optional[bool] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class Secret(BaseModel):
     metadata: Metadata
     data: Optional[dict] = None
-    string_data: Optional[dict] = None
+    string_data: Annotated[dict | None, Field(alias="stringData")] = None
     type: Optional[str] = None
     immutable: Optional[bool] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class Volume(BaseModel):
     name: str
-    config_maps: Optional[List[ConfigMap]] = None
+    config_maps: Annotated[List[ConfigMap] | None, Field(alias="configMaps")] = None
     secrets: Optional[List[Secret]] = None
-    empty_dirs: Optional[List[str]] = None
+    empty_dirs: Annotated[List[str] | None, Field(alias="emptyDirs")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class Pod(BaseModel):
@@ -144,12 +167,14 @@ class Pod(BaseModel):
 
 
 class StateTerminated(BaseModel):
-    exit_code: int
+    exit_code: Annotated[int, Field(alias="exitCode")]
     reason: Optional[str] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class StateRunning(BaseModel):
-    started_at: Optional[str] = None
+    started_at: Annotated[str | None, Field(alias="startedAt")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class StateWaiting(BaseModel):
@@ -170,27 +195,32 @@ class ContainerStatus(BaseModel):
 
 class PodStatus(BaseModel):
     name: str
-    uid: str
+    uid: Annotated[str, Field(alias="UID")]
+    jid: Annotated[str | None, Field(alias="JID")] = None
     namespace: str
     containers: List[ContainerStatus]
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class LogOpts(BaseModel):
-    tail: Optional[int] = None
-    limit_bytes: Optional[int] = None
-    timestamps: Optional[bool] = None
-    previous: Optional[bool] = None
-    since_seconds: Optional[int] = None
-    since_time: Optional[datetime.datetime] = None
+    tail: Annotated[int | None, Field(alias="Tail")] = None
+    limit_bytes: Annotated[int | None, Field(alias="LimitBytes")] = None
+    timestamps: Annotated[bool | None, Field(alias="Timestamps")] = None
+    previous: Annotated[bool | None, Field(alias="Previous")]
+    since_seconds: Annotated[int | None, Field(alias="SinceSeconds")] = None
+    since_time: Annotated[datetime.datetime | None, Field(alias="SinceTime")] = None
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class LogRequest(BaseModel):
-    namespace: str
-    pod_uid: str
-    pod_name: str
-    container_name: str
-    opts: LogOpts
+    namespace: Annotated[str, Field(alias="Namespace")]
+    pod_uid: Annotated[str, Field(alias="PodUID")]
+    pod_name: Annotated[str, Field(alias="PodName")]
+    container_name: Annotated[str, Field(alias="ContainerName")]
+    opts: Annotated[LogOpts, Field(alias="Opts")]
+    model_config = ConfigDict(populate_by_name=True)
 
 class CreateStruct(BaseModel):
-	pod_uid: str
-	pod_jid: str
+    pod_uid: Annotated[str, Field(alias="PodUID")]
+    pod_jid: Annotated[str, Field(alias="PodJID")]
+    model_config = ConfigDict(populate_by_name=True)

--- a/example/interlink/spec.py
+++ b/example/interlink/spec.py
@@ -3,6 +3,7 @@ from typing import Annotated, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+
 class Metadata(BaseModel):
     name: Optional[str] = None
     namespace: Optional[str] = None
@@ -35,8 +36,12 @@ class SecretKeySelector(BaseModel):
 
 
 class EnvVarSource(BaseModel):
-    config_map_key_ref: Annotated[ConfigMapKeySelector | None, Field(alias="configMapKeyRef")] = None
-    secret_key_ref: Annotated[SecretKeySelector | None, Field(alias="secretKeyRef")] = None
+    config_map_key_ref: Annotated[
+        ConfigMapKeySelector | None, Field(alias="configMapKeyRef")
+    ] = None
+    secret_key_ref: Annotated[
+        SecretKeySelector | None, Field(alias="secretKeyRef")
+    ] = None
     model_config = ConfigDict(populate_by_name=True)
 
 
@@ -48,10 +53,14 @@ class EnvVar(BaseModel):
 
 
 class SecurityContext(BaseModel):
-    allow_privilege_escalation: Annotated[bool | None, Field(alias="allowPrivilegeEscalation")] = None
+    allow_privilege_escalation: Annotated[
+        bool | None, Field(alias="allowPrivilegeEscalation")
+    ] = None
     privileged: Optional[bool] = None
     proc_mount: Annotated[str | None, Field(alias="procMount")] = None
-    read_only_file_system: Annotated[bool | None, Field(alias="readOnlyFileSystem")] = None
+    read_only_file_system: Annotated[
+        bool | None, Field(alias="readOnlyFileSystem")
+    ] = None
     run_as_group: Annotated[int | None, Field(alias="runAsGroup")] = None
     run_as_non_root: Annotated[bool | None, Field(alias="runAsNonRoot")] = None
     run_as_user: Annotated[int | None, Field(alias="runAsUser")] = None
@@ -76,7 +85,9 @@ class Container(BaseModel):
     resources: Optional[dict] = Field({})
     volume_mounts: Annotated[List[VolumeMount] | None, Field(alias="volumeMounts")] = []
     env: Optional[List[EnvVar]] = None
-    security_context: Annotated[SecurityContext | None, Field(alias="securityContext")] = None
+    security_context: Annotated[
+        SecurityContext | None, Field(alias="securityContext")
+    ] = None
     ports: Optional[List[ContainerPort]] = None
     model_config = ConfigDict(populate_by_name=True)
 
@@ -120,13 +131,17 @@ class PodVolume(BaseModel):
 
 class PodSpec(BaseModel):
     containers: List[Container]
-    init_containers: Annotated[List[Container] | None, Field(alias="initContainers")] = None
+    init_containers: Annotated[
+        List[Container] | None, Field(alias="initContainers")
+    ] = None
     volumes: Optional[List[PodVolume]] = None
     preemption_policy: Annotated[str | None, Field(alias="preemptionPolicy")] = None
     priority_class_name: Annotated[str | None, Field(alias="priorityClassName")] = None
     priority: Optional[int] = None
     restart_policy: Annotated[str | None, Field(alias="restartPolicy")] = None
-    termination_grace_period_seconds: Annotated[int | None, Field(alias="terminationGracePeriodSeconds")] = None
+    termination_grace_period_seconds: Annotated[
+        int | None, Field(alias="terminationGracePeriodSeconds")
+    ] = None
     model_config = ConfigDict(populate_by_name=True)
 
 
@@ -219,6 +234,7 @@ class LogRequest(BaseModel):
     container_name: Annotated[str, Field(alias="ContainerName")]
     opts: Annotated[LogOpts, Field(alias="Opts")]
     model_config = ConfigDict(populate_by_name=True)
+
 
 class CreateStruct(BaseModel):
     pod_uid: Annotated[str, Field(alias="PodUID")]


### PR DESCRIPTION
# Summary

## camelCase support
The Python sidecar interface defines model properties using snake_case notation (see [spec.py](https://github.com/interTwin-eu/interLink/blob/main/example/interlink/spec.py)), however the interLink API server invokes sidecar API with objects defined in camelCase notation.
Using [Pydantic alias](https://docs.pydantic.dev/latest/concepts/fields/#field-aliases) feature, we enable Pydantic to create models parsing data using camelCase notation.

## Container ports
We enriched the Container model with parameter ports defined as a list of ContainerPort models. 