### PR TITLE
Remove timeout from socket interlink server

### DIFF
--- a/cmd/interlink/main.go
+++ b/cmd/interlink/main.go
@@ -131,9 +131,7 @@ func main() {
 			os.Exit(1)
 		}()
 		server := http.Server{
-			Handler:           mutex,
-			ReadTimeout:       30 * time.Second,
-			ReadHeaderTimeout: 10 * time.Second,
+			Handler: mutex,
 		}
 
 		log.G(ctx).Info(socket)


### PR DESCRIPTION
Timeout in http server failed to manage connections when using unix socket. Therefore timeout and timeoutheader are now removed from socket case

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
