### PR TITLE
ci: support aarch64 builds

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -38,7 +38,7 @@ jobs:
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/interlink/virtual-kubelet-inttw:${{ env.RELEASE_VERSION }}
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/interlink/virtual-kubelet-inttw:latest
           file: ./docker/Dockerfile.vk
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/aarch64
           build-args: |
             VERSION=${{ env.RELEASE_VERSION }} 
       - name: Build container base image interlink
@@ -50,7 +50,7 @@ jobs:
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/interlink/interlink:${{ env.RELEASE_VERSION }}
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/interlink/interlink:latest
           file: ./docker/Dockerfile.interlink
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/aarch64
           
   virtual-kubelet-refresh-token:
     runs-on: ubuntu-latest
@@ -83,4 +83,4 @@ jobs:
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/interlink/virtual-kubelet-inttw-refresh:${{ env.RELEASE_VERSION }}
             ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/interlink/virtual-kubelet-inttw-refresh:latest
           file: ./docker/Dockerfile.refresh-token
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/aarch64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,7 @@ builds:
     goarch:
       - arm64
       - amd64
+      - aaarch64
     main: ./cmd/virtual-kubelet
   - id: "interlink-api"
     binary: interlink
@@ -31,6 +32,7 @@ builds:
       - arm64
       - amd64
       - ppc64le
+      - aaarch64
     main: ./cmd/interlink
   - id: "installer"
     binary: interlink-installer
@@ -43,6 +45,7 @@ builds:
       - arm64
       - amd64
       - ppc64le
+      - aaarch64
     main: ./cmd/installer
   - id: "ssh-tunnel"
     binary: ssh-tunnel
@@ -55,6 +58,7 @@ builds:
       - arm64
       - amd64
       - ppc64le
+      - aaarch64
     main: ./cmd/ssh-tunnel
 archives:
   - name_template: >-


### PR DESCRIPTION
update github actions workflows and goreleaser to support aarch64.

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

Add aarch64 build and goreleaser support

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
fixes #305 