### PR TITLE
Fix figure labels in docs/Cookbook scenarios tabs

### DIFF
--- a/docs/docs/Cookbook.mdx
+++ b/docs/docs/Cookbook.mdx
@@ -14,7 +14,7 @@ These are practical recipes for different deployment scenarios.
 Select here the tab with the scenario you want deploy:
 
 <Tabs groupId="scenarios">
-  <TabItem value="incluster" label="In-cluster" default>
+  <TabItem value="edge" label="Edge node">
 <ThemedImage 
         alt="Docusaurus themed image"
         sources={{
@@ -23,7 +23,7 @@ Select here the tab with the scenario you want deploy:
         }}
 />
   </TabItem>
-  <TabItem value="edge" label="Edge node">
+  <TabItem value="incluster" label="In-cluster" default>
 <ThemedImage 
         alt="Docusaurus themed image"
         sources={{

--- a/docs/docs/Cookbook.mdx
+++ b/docs/docs/Cookbook.mdx
@@ -14,7 +14,7 @@ These are practical recipes for different deployment scenarios.
 Select here the tab with the scenario you want deploy:
 
 <Tabs groupId="scenarios">
-  <TabItem value="edge" label="Edge node">
+  <TabItem value="incluster" label="In-cluster" default>
 <ThemedImage 
         alt="Docusaurus themed image"
         sources={{
@@ -23,7 +23,7 @@ Select here the tab with the scenario you want deploy:
         }}
 />
   </TabItem>
-  <TabItem value="incluster" label="In-cluster" default>
+  <TabItem value="edge" label="Edge node">
 <ThemedImage 
         alt="Docusaurus themed image"
         sources={{

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -53,8 +53,8 @@ This scenario involves deploying a Virtual Kubelet along with the interLink API 
 <ThemedImage 
         alt="Docusaurus themed image"
         sources={{
-          light: useBaseUrl('/img/scenario-1_light.svg'),
-          dark: useBaseUrl('/img/scenario-1_dark.svg'),
+          light: useBaseUrl('/img/scenario-2_light.svg'),
+          dark: useBaseUrl('/img/scenario-2_dark.svg'),
         }}
 />
 
@@ -66,8 +66,8 @@ In this scenario, the Virtual Kubelet communicates with remote services deployed
 <ThemedImage 
         alt="Docusaurus themed image"
         sources={{
-          light: useBaseUrl('/img/scenario-2_light.svg'),
-          dark: useBaseUrl('/img/scenario-2_dark.svg'),
+          light: useBaseUrl('/img/scenario-1_light.svg'),
+          dark: useBaseUrl('/img/scenario-1_dark.svg'),
         }}
 />
 


### PR DESCRIPTION
Fix swapped figures labels "Edge" <-> "In-cluster" in Cookbook scenarios tabs

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Swap the labels associated to scenario-1 (In-cluster) and scenario-2 (Edge) figures in Cookbook

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** `na`
