### PR TITLE
fix: interlink socket being overriden

### DIFF
--- a/cmd/installer/templates/interlink-install.sh
+++ b/cmd/installer/templates/interlink-install.sh
@@ -125,7 +125,6 @@ start() {
       echo $! > $HOME/.interlink/oauth2-proxy.pid
       ;;
     github)
-      touch  $HOME/.interlink/interlink.sock
       $HOME/.interlink/bin/oauth2-proxy \
           --client-id {{.OAUTH.ClientID}} \
           --client-secret {{.OAUTH.ClientSecret}} \


### PR DESCRIPTION
# Summary
The interlink socket is being overriden here. The existing interlink socket created by the binary is in the process deleted. This issue only happens when using github as the IAM provider and the`touch` command is only run when the oauth2-rpxy for github is being setup.

---

**Related issue :**
fixes #321 
