### PR TITLE
Authz headers handled and set as attributes for traces 

### DIFF
--- a/cmd/interlink/main.go
+++ b/cmd/interlink/main.go
@@ -67,7 +67,7 @@ func main() {
 	defer cancel()
 
 	if os.Getenv("ENABLE_TRACING") == "1" {
-		shutdown, err := interlink.InitTracer(ctx)
+		shutdown, err := interlink.InitTracer(ctx, "InterLink-Plugin-")
 		if err != nil {
 			log.G(ctx).Fatal(err)
 		}

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -147,7 +147,7 @@ func main() {
 	log.G(ctx).Info("Config dump", interLinkConfig)
 
 	if os.Getenv("ENABLE_TRACING") == "1" {
-		shutdown, err := interlink.InitTracer(ctx)
+		shutdown, err := interlink.InitTracer(ctx, "VK-InterLink-")
 		if err != nil {
 			log.G(ctx).Fatal(err)
 		}

--- a/docs/docs/guides/05-monitoring.md
+++ b/docs/docs/guides/05-monitoring.md
@@ -93,6 +93,12 @@ helm upgrade --install helm-vk-monitoring-release interlink-monitoring-stack/ -n
 
 5. Deploy (or re-deploy) your Virtual Kubelet stack setting the ```TELEMETRY_ENDPOINT``` Environment Variable to your actual endpoint. 
 If not set, it defaults to ```localhost:4317```. Remember to enable the monitoring by also setting ```ENABLE_TRACING``` to 1.
+If you are using an external Tempo instance which is not in the same cluster as the VK and mutual TLS is enabled, you have to set the
+```TELEMETRY_CA_CRT_FILEPATH``` that points to the CA certificate file used by Tempo to sign the certificates, 
+the ```TELEMETRY_CLIENT_KEY_FILEPATH``` that points to the client key file used by the VK to authenticate itself to Tempo and
+the ```TELEMETRY_CLIENT_CRT_FILEPATH``` that points to the client certificate file used by the VK to authenticate itself to Tempo.
+Finally, if the TLS certificate on Tempo are not verfied by unknown authorities, you can set the ```TELEMETRY_INSECURE_SKIP_VERIFY```
+to true.
 
 6. Access Grafana dashboard through the domain you defined in the `values.yaml` file with the credentials you defined in the `values.yaml` file. 
 

--- a/pkg/interlink/api/create.go
+++ b/pkg/interlink/api/create.go
@@ -25,6 +25,7 @@ func (h *InterLinkHandler) CreateHandler(w http.ResponseWriter, r *http.Request)
 	))
 	defer span.End()
 	defer types.SetDurationSpan(start, span)
+	defer types.SetInfoFromHeaders(span, &r.Header)
 
 	log.G(h.Ctx).Info("InterLink: received Create call")
 

--- a/pkg/interlink/api/delete.go
+++ b/pkg/interlink/api/delete.go
@@ -26,6 +26,7 @@ func (h *InterLinkHandler) DeleteHandler(w http.ResponseWriter, r *http.Request)
 	))
 	defer span.End()
 	defer types.SetDurationSpan(start, span)
+	defer types.SetInfoFromHeaders(span, &r.Header)
 
 	log.G(h.Ctx).Info("InterLink: received Delete call")
 

--- a/pkg/interlink/api/logs.go
+++ b/pkg/interlink/api/logs.go
@@ -25,6 +25,7 @@ func (h *InterLinkHandler) GetLogsHandler(w http.ResponseWriter, r *http.Request
 	))
 	defer span.End()
 	defer types.SetDurationSpan(start, span)
+	defer types.SetInfoFromHeaders(span, &r.Header)
 
 	sessionContext := GetSessionContext(r)
 	sessionContextMessage := GetSessionContextMessage(sessionContext)

--- a/pkg/interlink/api/ping.go
+++ b/pkg/interlink/api/ping.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Ping is just a very basic Ping function
-func (h *InterLinkHandler) Ping(w http.ResponseWriter, _ *http.Request) {
+func (h *InterLinkHandler) Ping(w http.ResponseWriter, r *http.Request) {
 	start := time.Now().UnixMicro()
 	tracer := otel.Tracer("interlink-API")
 	_, span := tracer.Start(h.Ctx, "PingAPI", trace.WithAttributes(
@@ -27,6 +27,7 @@ func (h *InterLinkHandler) Ping(w http.ResponseWriter, _ *http.Request) {
 	))
 	defer span.End()
 	defer types.SetDurationSpan(start, span)
+	defer types.SetInfoFromHeaders(span, &r.Header)
 
 	log.G(h.Ctx).Info("InterLink: received Ping call")
 

--- a/pkg/interlink/api/status.go
+++ b/pkg/interlink/api/status.go
@@ -27,6 +27,7 @@ func (h *InterLinkHandler) StatusHandler(w http.ResponseWriter, r *http.Request)
 	))
 	defer span.End()
 	defer types.SetDurationSpan(start, span)
+	defer types.SetInfoFromHeaders(span, &r.Header)
 	statusCode := http.StatusOK
 	var pods []*v1.Pod
 	log.G(h.Ctx).Info("InterLink: received GetStatus call")

--- a/pkg/interlink/config.go
+++ b/pkg/interlink/config.go
@@ -95,6 +95,11 @@ func SetupTelemetry(ctx context.Context, serviceName string) (*sdktrace.TracerPr
 			return nil, fmt.Errorf("client certificate file path not provided. Since a CA certificate is provided, a client certificate is required for mutual TLS")
 		}
 
+		insecureSkipVerify := false
+		if os.Getenv("TELEMETRY_INSECURE_SKIP_VERIFY") == "true" {
+			insecureSkipVerify = true
+		}
+
 		certPool := x509.NewCertPool()
 		if !certPool.AppendCertsFromPEM(caCert) {
 			return nil, fmt.Errorf("failed to append CA certificate")
@@ -109,7 +114,7 @@ func SetupTelemetry(ctx context.Context, serviceName string) (*sdktrace.TracerPr
 			Certificates:       []tls.Certificate{cert},
 			RootCAs:            certPool,
 			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: true, // #nosec
+			InsecureSkipVerify: insecureSkipVerify,
 		}
 
 		creds := credentials.NewTLS(tlsConfig)

--- a/pkg/interlink/config.go
+++ b/pkg/interlink/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	DataRootFolder    string `yaml:"DataRootFolder"`
 }
 
-func SetupTelemetry(ctx context.Context) (*sdktrace.TracerProvider, error) {
+func SetupTelemetry(ctx context.Context, serviceName string) (*sdktrace.TracerProvider, error) {
 	log.G(ctx).Info("Tracing is enabled, setting up the TracerProvider")
 
 	// Get the TELEMETRY_UNIQUE_ID from the environment, if it is not set, use the hostname
@@ -45,23 +45,19 @@ func SetupTelemetry(ctx context.Context) (*sdktrace.TracerProvider, error) {
 		log.G(ctx).Info("No TELEMETRY_UNIQUE_ID set, generating a new one")
 		newUUID := uuid.New()
 		uniqueID = newUUID.String()
-		log.G(ctx).Info("Generated unique ID: ", uniqueID, " use VK-InterLink-"+uniqueID+" as service name from Grafana")
+		log.G(ctx).Info("Generated unique ID: ", uniqueID, " use "+serviceName+"-"+uniqueID+" as service name from Grafana")
 	}
-	// Create a new resource with the service name set to the TELEMETRY_UNIQUE_ID
-	// The nomenclature VK-InterLink-<TELEMETRY_UNIQUE_ID> is used to identify the service in Grafana.
-	// VK-InterLink-<TELEMETRY_UNIQUE_ID> means that the traces are coming from Virtual Kubelet
-	// and are related to the call that are made for the InterLink API service
 
-	serviceName := "VK-InterLink-" + uniqueID
+	fullServiceName := serviceName + uniqueID
 
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			// the service name used to display traces in backends
-			semconv.ServiceName(serviceName),
+			semconv.ServiceName(fullServiceName),
 		),
 	)
 	if err != nil {
-		return &sdktrace.TracerProvider{}, fmt.Errorf("failed to create resource: %w", err)
+		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
@@ -113,24 +109,20 @@ func SetupTelemetry(ctx context.Context) (*sdktrace.TracerProvider, error) {
 			Certificates:       []tls.Certificate{cert},
 			RootCAs:            certPool,
 			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: false,
-		}
-		creds := credentials.NewTLS(tlsConfig)
-		conn, err = grpc.NewClient(otlpEndpoint, grpc.WithTransportCredentials(creds))
-		if err != nil {
-			return nil, fmt.Errorf("Failed to connect to open telemetry connector: %w", err)
+			InsecureSkipVerify: true,
 		}
 
+		creds := credentials.NewTLS(tlsConfig)
+		conn, err = grpc.NewClient(otlpEndpoint, grpc.WithTransportCredentials(creds))
 	} else {
-		// if the CA certificate is not provided, use an insecure connection
-		// this means that the telemetry collector is not using a certificate, i.e. is inside the k8s cluster
 		conn, err = grpc.NewClient(otlpEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			return nil, fmt.Errorf("Failed to connect to open telemetry connector: %w", err)
-		}
 	}
 
 	conn.WaitForStateChange(ctx, connectivity.Ready)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC connection to collector: %w", err)
+	}
 
 	// Set up a trace exporter
 	traceExporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(conn))
@@ -150,12 +142,13 @@ func SetupTelemetry(ctx context.Context) (*sdktrace.TracerProvider, error) {
 
 	// set global propagator to tracecontext (the default is no-op).
 	otel.SetTextMapPropagator(propagation.TraceContext{})
+
 	return tracerProvider, nil
 }
 
-func InitTracer(ctx context.Context) (func(context.Context) error, error) {
+func InitTracer(ctx context.Context, serviceName string) (func(context.Context) error, error) {
 	// Get the TELEMETRY_UNIQUE_ID from the environment, if it is not set, use the hostname
-	tracerProvider, err := SetupTelemetry(ctx)
+	tracerProvider, err := SetupTelemetry(ctx, serviceName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/interlink/config.go
+++ b/pkg/interlink/config.go
@@ -114,7 +114,7 @@ func SetupTelemetry(ctx context.Context, serviceName string) (*sdktrace.TracerPr
 			Certificates:       []tls.Certificate{cert},
 			RootCAs:            certPool,
 			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: insecureSkipVerify,
+			InsecureSkipVerify: insecureSkipVerify, // #nosec
 		}
 
 		creds := credentials.NewTLS(tlsConfig)

--- a/pkg/interlink/config.go
+++ b/pkg/interlink/config.go
@@ -109,11 +109,14 @@ func SetupTelemetry(ctx context.Context, serviceName string) (*sdktrace.TracerPr
 			Certificates:       []tls.Certificate{cert},
 			RootCAs:            certPool,
 			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: true, // #nosec
 		}
 
 		creds := credentials.NewTLS(tlsConfig)
 		conn, err = grpc.NewClient(otlpEndpoint, grpc.WithTransportCredentials(creds))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gRPC client: %w", err)
+		}
 	} else {
 		conn, err = grpc.NewClient(otlpEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}

--- a/pkg/interlink/spans.go
+++ b/pkg/interlink/spans.go
@@ -1,6 +1,7 @@
 package interlink
 
 import (
+	"net/http"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -29,4 +30,18 @@ func SetDurationSpan(startTime int64, span trace.Span, opts ...SpanOption) {
 	if config.SetHTTPCode {
 		span.SetAttributes(attribute.Int("exit.code", config.HTTPReturnCode))
 	}
+}
+
+func SetInfoFromHeaders(span trace.Span, h *http.Header) {
+	var xForwardedEmail, xForwardedUser string
+	if xForwardedEmail = h.Get("X-Forwarded-Email"); xForwardedEmail == "" {
+		xForwardedEmail = "unknown"
+	}
+	if xForwardedUser = h.Get("X-Forwarded-User"); xForwardedUser == "" {
+		xForwardedUser = "unknown"
+	}
+	span.SetAttributes(
+		attribute.String("X-Forwarded-Email", xForwardedEmail),
+		attribute.String("X-Forwarded-User", xForwardedUser),
+	)
 }


### PR DESCRIPTION
The *SetupTelemetry* function has been updated to dynamically create a service with a unique name depending on whether it is invoked by the VK or the InterLink API. 
Additionally, information extracted from the AUTHZ headers is now included as attributes of the span associated with different HTTP calls.