### PR TITLE
Improve Pod Container Status Handling

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -24,6 +24,12 @@ We are integrating interLink in order to provide integration of HPC centers with
 
 ## HPC supercomputing centers
 
+### IJS & IZUM
+
+Project: interTwin
+
+EuroHPC Vega is the first operational system under the EuroHPC initiative and an early adopter of interTwin framework providing resources through interLink service. It provides critical support and counseling from both project partners (JSI & IZUM), infrastructure, and edge VM for the development and utilization of interLink, fostering the exploitation of the HPC Vega environment within the InterTwin project. 
+
 ### CNES
 
 Project: LISA DDPC

--- a/pkg/interlink/api/status.go
+++ b/pkg/interlink/api/status.go
@@ -80,7 +80,6 @@ func (h *InterLinkHandler) StatusHandler(w http.ResponseWriter, r *http.Request)
 
 		log.G(h.Ctx).Info("InterLink: forwarding GetStatus call to sidecar")
 		req.Header.Set("Content-Type", "application/json")
-		log.G(h.Ctx).Debug("Interlink get status request content:", req)
 
 		sessionContext := GetSessionContext(r)
 		bodyBytes, err = ReqWithError(h.Ctx, req, w, start, span, false, true, sessionContext, h.ClientHTTP)
@@ -127,7 +126,6 @@ func (h *InterLinkHandler) StatusHandler(w http.ResponseWriter, r *http.Request)
 		log.G(h.Ctx).Error(err)
 		return
 	}
-	log.G(h.Ctx).Debug("InterLink: status " + string(returnValue))
 
 	w.WriteHeader(statusCode)
 	_, err = w.Write(returnValue)

--- a/pkg/interlink/types.go
+++ b/pkg/interlink/types.go
@@ -15,11 +15,12 @@ type PodCreateRequests struct {
 
 // PodStatus is a simplified v1.Pod struct, holding only necessary variables to uniquely identify a job/service in the sidecar. It is used to request
 type PodStatus struct {
-	PodName      string               `json:"name"`
-	PodUID       string               `json:"UID"`
-	PodNamespace string               `json:"namespace"`
-	JobID        string               `json:"JID"`
-	Containers   []v1.ContainerStatus `json:"containers"`
+	PodName        string               `json:"name"`
+	PodUID         string               `json:"UID"`
+	PodNamespace   string               `json:"namespace"`
+	JobID          string               `json:"JID"`
+	Containers     []v1.ContainerStatus `json:"containers"`
+	InitContainers []v1.ContainerStatus `json:"initContainers"`
 }
 
 // CreateStruct is the response to be received from interLink whenever asked to create a pod. It will allow for mapping remote ID with the pod UUID

--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -25,6 +25,7 @@ import (
 )
 
 const PodPhaseInitialize = "Initializing"
+const PodPhaseCompleted = "Completed"
 
 func failedMount(ctx context.Context, failed *bool, name string, pod *v1.Pod, p *Provider) error {
 	*failed = true
@@ -565,188 +566,194 @@ func checkPodsStatus(ctx context.Context, p *Provider, podsList []*v1.Pod, token
 
 				log.G(ctx).Debug(fmt.Sprintln("Get status from remote status len: ", len(podRemoteStatus.Containers)))
 				// avoid asking for status too early, when etcd as not been updated
-				if podRemoteStatus.PodName != "" {
 
-					// get pod reference from cluster etcd
-					podRefInCluster, err := p.GetPod(ctx, podRemoteStatus.PodNamespace, podRemoteStatus.PodName)
-					if err != nil {
-						log.G(ctx).Warning(err)
-						continue
-					}
-					log.G(ctx).Debug(fmt.Sprintln("Get pod from k8s cluster status: ", podRefInCluster.Status.ContainerStatuses))
+				if podRemoteStatus.PodName == "" {
+					log.G(ctx).Warning("PodName is empty, skipping")
+					continue
+				}
 
-					// if the PodUID match with the one in etcd we are talking of the same thing. GOOD
-					if podRemoteStatus.PodUID == string(podRefInCluster.UID) {
-						podInit := false                     // if a init container is running, the other containers phase is PodInitializing
-						podRunning := false                  // if a normale container is running, the phase is PodRunning
-						podErrored := false                  // if a container is in error, the phase is PodFailed
-						podCompleted := false                // if all containers are terminated, the phase is PodSucceeded, but if one is in error, the phase is PodFailed
-						podWaitingForInitContainers := false // if init containers are waiting, the phase is PodPending
-						failedReason := ""
+				// get pod reference from cluster etcd
+				podRefInCluster, err := p.GetPod(ctx, podRemoteStatus.PodNamespace, podRemoteStatus.PodName)
+				if err != nil {
+					log.G(ctx).Warning(err)
+					continue
+				}
+				log.G(ctx).Debug(fmt.Sprintln("Get pod from k8s cluster status: ", podRefInCluster.Status.ContainerStatuses))
 
-						nContainersInPod := len(podRemoteStatus.Containers)
-						counterOfTerminatedContainers := 0
+				// if the PodUID match with the one in etcd we are talking of the same thing. GOOD
+				if podRemoteStatus.PodUID == string(podRefInCluster.UID) {
+					podInit := false                     // if a init container is running, the other containers phase is PodInitializing
+					podRunning := false                  // if a normale container is running, the phase is PodRunning
+					podErrored := false                  // if a container is in error, the phase is PodFailed
+					podCompleted := false                // if all containers are terminated, the phase is PodSucceeded, but if one is in error, the phase is PodFailed
+					podWaitingForInitContainers := false // if init containers are waiting, the phase is PodPending
+					failedReason := ""
 
-						nInitContainersInPod := len(podRemoteStatus.InitContainers)
-						counterOfTerminatedInitContainers := 0
+					nContainersInPod := len(podRemoteStatus.Containers)
+					counterOfTerminatedContainers := 0
 
-						log.G(ctx).Debug("Number of containers in POD:      " + strconv.Itoa(nContainersInPod))
-						log.G(ctx).Debug("Number of init containers in POD: " + strconv.Itoa(nContainersInPod))
+					nInitContainersInPod := len(podRemoteStatus.InitContainers)
+					counterOfTerminatedInitContainers := 0
 
-						// if there are init containers, we need to check them first
-						if nInitContainersInPod > 0 {
+					log.G(ctx).Debug("Number of containers in POD:      " + strconv.Itoa(nContainersInPod))
+					log.G(ctx).Debug("Number of init containers in POD: " + strconv.Itoa(nContainersInPod))
 
-							log.G(ctx).Debug("Init containers detected, going to check them first")
+					// if there are init containers, we need to check them first
+					if nInitContainersInPod > 0 {
 
-							for _, containerRemoteStatus := range podRemoteStatus.InitContainers {
-								index := 0
-								foundCt := false
+						log.G(ctx).Debug("Init containers detected, going to check them first")
 
-								for i, checkedContainer := range podRefInCluster.Status.InitContainerStatuses {
-									if checkedContainer.Name == containerRemoteStatus.Name {
-										foundCt = true
-										index = i
-									}
-								}
-
-								if !foundCt {
-									podRefInCluster.Status.InitContainerStatuses = append(podRefInCluster.Status.InitContainerStatuses, containerRemoteStatus)
-								} else {
-									podRefInCluster.Status.InitContainerStatuses[index] = containerRemoteStatus
-								}
-
-								switch {
-								case containerRemoteStatus.State.Terminated != nil:
-									counterOfTerminatedInitContainers = counterOfTerminatedInitContainers + 1
-									podRefInCluster.Status.InitContainerStatuses[index].State.Terminated.ExitCode = containerRemoteStatus.State.Terminated.ExitCode
-									podRefInCluster.Status.InitContainerStatuses[index].State.Terminated.Reason = "Completed"
-									if containerRemoteStatus.State.Terminated.ExitCode != 0 {
-										podErrored = true
-										failedReason = "Error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode))
-										podRefInCluster.Status.InitContainerStatuses[index].State.Terminated.Reason = failedReason
-										log.G(ctx).Error("Container " + containerRemoteStatus.Name + " exited with error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode)))
-									}
-								case containerRemoteStatus.State.Waiting != nil:
-									log.G(ctx).Info("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is setting up on Sidecar")
-									podWaitingForInitContainers = true
-									podRefInCluster.Status.InitContainerStatuses[index].State.Waiting = containerRemoteStatus.State.Waiting
-								case containerRemoteStatus.State.Running != nil:
-									podInit = true
-									log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is running on Sidecar")
-									podRefInCluster.Status.InitContainerStatuses[index].State.Running = containerRemoteStatus.State.Running
-									podRefInCluster.Status.InitContainerStatuses[index].State.Waiting = nil
-								}
-							}
-							if counterOfTerminatedInitContainers == nInitContainersInPod {
-								podWaitingForInitContainers = false
-							}
-						}
-
-						for _, containerRemoteStatus := range podRemoteStatus.Containers {
+						for _, containerRemoteStatus := range podRemoteStatus.InitContainers {
 							index := 0
 							foundCt := false
 
-							for i, checkedContainer := range podRefInCluster.Status.ContainerStatuses {
+							for i, checkedContainer := range podRefInCluster.Status.InitContainerStatuses {
 								if checkedContainer.Name == containerRemoteStatus.Name {
 									foundCt = true
 									index = i
+									break
 								}
 							}
 
-							// if it is the first time checking the container, append it to the pod containers, otherwise just update the correct item
 							if !foundCt {
-								podRefInCluster.Status.ContainerStatuses = append(podRefInCluster.Status.ContainerStatuses, containerRemoteStatus)
+								podRefInCluster.Status.InitContainerStatuses = append(podRefInCluster.Status.InitContainerStatuses, containerRemoteStatus)
 							} else {
-								podRefInCluster.Status.ContainerStatuses[index] = containerRemoteStatus
+								podRefInCluster.Status.InitContainerStatuses[index] = containerRemoteStatus
 							}
 
-							// if the pod is waiting for the starting of the init containers or some of them are still running
-							// all the other containers are in waiting state
-							if podWaitingForInitContainers || podInit {
-								podRefInCluster.Status.ContainerStatuses[index].State.Waiting = &v1.ContainerStateWaiting{Reason: "Waiting for init containers"}
-								podRefInCluster.Status.ContainerStatuses[index].State.Running = nil
-								podRefInCluster.Status.ContainerStatuses[index].State.Terminated = nil
-								if podInit {
-									podRefInCluster.Status.ContainerStatuses[index].State.Waiting.Reason = "Init:" + strconv.Itoa(counterOfTerminatedInitContainers) + "/" + strconv.Itoa(nInitContainersInPod)
-								} else {
-									podRefInCluster.Status.ContainerStatuses[index].State.Waiting.Reason = "PodInitializing"
+							switch {
+							case containerRemoteStatus.State.Terminated != nil:
+								counterOfTerminatedInitContainers++
+								podRefInCluster.Status.InitContainerStatuses[index].State.Terminated.ExitCode = containerRemoteStatus.State.Terminated.ExitCode
+								podRefInCluster.Status.InitContainerStatuses[index].State.Terminated.Reason = PodPhaseCompleted
+								if containerRemoteStatus.State.Terminated.ExitCode != 0 {
+									podErrored = true
+									failedReason = "Error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode))
+									podRefInCluster.Status.InitContainerStatuses[index].State.Terminated.Reason = failedReason
+									log.G(ctx).Error("Container " + containerRemoteStatus.Name + " exited with error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode)))
 								}
-							} else {
-								// if plugin cannot return any non-terminated container set the status to terminated
-								// if the exit code is != 0 get the error  and set error reason + rememeber to set pod to failed
-								switch {
-								case containerRemoteStatus.State.Terminated != nil:
-									log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is not running on Plugin side")
-									counterOfTerminatedContainers = counterOfTerminatedContainers + 1
-									podRefInCluster.Status.ContainerStatuses[index].State.Terminated.Reason = "Completed"
-									if containerRemoteStatus.State.Terminated.ExitCode != 0 {
-										podErrored = true
-										failedReason = "Error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode))
-										podRefInCluster.Status.ContainerStatuses[index].State.Terminated.Reason = failedReason
-										log.G(ctx).Error("Container " + containerRemoteStatus.Name + " exited with error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode)))
-									}
-								case containerRemoteStatus.State.Waiting != nil:
-									log.G(ctx).Info("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is setting up on Sidecar")
-									podRunning = true
-								case containerRemoteStatus.State.Running != nil:
-									podRunning = true
-									log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is running on Sidecar")
-								}
+							case containerRemoteStatus.State.Waiting != nil:
+								log.G(ctx).Info("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is setting up on Sidecar")
+								podWaitingForInitContainers = true
+								podRefInCluster.Status.InitContainerStatuses[index].State.Waiting = containerRemoteStatus.State.Waiting
+							case containerRemoteStatus.State.Running != nil:
+								podInit = true
+								log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is running on Sidecar")
+								podRefInCluster.Status.InitContainerStatuses[index].State.Running = containerRemoteStatus.State.Running
+								podRefInCluster.Status.InitContainerStatuses[index].State.Waiting = nil
 							}
 						}
-						if counterOfTerminatedContainers == nContainersInPod {
-							podCompleted = true
+						if counterOfTerminatedInitContainers == nInitContainersInPod {
+							podWaitingForInitContainers = false
+						}
+					}
+
+					for _, containerRemoteStatus := range podRemoteStatus.Containers {
+						index := 0
+						foundCt := false
+
+						for i, checkedContainer := range podRefInCluster.Status.ContainerStatuses {
+							if checkedContainer.Name == containerRemoteStatus.Name {
+								foundCt = true
+								index = i
+								break
+							}
 						}
 
-						if podCompleted {
-							// it means that all containers are terminated, check if some of them are errored
-							if podErrored {
-								podRefInCluster.Status.Phase = v1.PodFailed
-								podRefInCluster.Status.Reason = failedReason
-								// override all the ContainerStatuses to set Reason to failedReason
-								for i := range podRefInCluster.Status.ContainerStatuses {
-									podRefInCluster.Status.ContainerStatuses[i].State.Terminated.Reason = failedReason
-								}
+						// if it is the first time checking the container, append it to the pod containers, otherwise just update the correct item
+						if !foundCt {
+							podRefInCluster.Status.ContainerStatuses = append(podRefInCluster.Status.ContainerStatuses, containerRemoteStatus)
+						} else {
+							podRefInCluster.Status.ContainerStatuses[index] = containerRemoteStatus
+						}
+
+						// if the pod is waiting for the starting of the init containers or some of them are still running
+						// all the other containers are in waiting state
+						if podWaitingForInitContainers || podInit {
+							podRefInCluster.Status.ContainerStatuses[index].State.Waiting = &v1.ContainerStateWaiting{Reason: "Waiting for init containers"}
+							podRefInCluster.Status.ContainerStatuses[index].State.Running = nil
+							podRefInCluster.Status.ContainerStatuses[index].State.Terminated = nil
+							if podInit {
+								podRefInCluster.Status.ContainerStatuses[index].State.Waiting.Reason = "Init:" + strconv.Itoa(counterOfTerminatedInitContainers) + "/" + strconv.Itoa(nInitContainersInPod)
 							} else {
-								podRefInCluster.Status.Conditions = append(podRefInCluster.Status.Conditions, v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionFalse})
-								podRefInCluster.Status.Phase = v1.PodSucceeded
-								podRefInCluster.Status.Reason = "Completed"
+								podRefInCluster.Status.ContainerStatuses[index].State.Waiting.Reason = "PodInitializing"
 							}
 						} else {
-							if podInit {
-								podRefInCluster.Status.Phase = v1.PodPending
-								podRefInCluster.Status.Reason = "Init"
+							// if plugin cannot return any non-terminated container set the status to terminated
+							// if the exit code is != 0 get the error  and set error reason + rememeber to set pod to failed
+							switch {
+							case containerRemoteStatus.State.Terminated != nil:
+								log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is not running on Plugin side")
+								counterOfTerminatedContainers++
+								podRefInCluster.Status.ContainerStatuses[index].State.Terminated.Reason = PodPhaseCompleted
+								if containerRemoteStatus.State.Terminated.ExitCode != 0 {
+									podErrored = true
+									failedReason = "Error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode))
+									podRefInCluster.Status.ContainerStatuses[index].State.Terminated.Reason = failedReason
+									log.G(ctx).Error("Container " + containerRemoteStatus.Name + " exited with error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode)))
+								}
+							case containerRemoteStatus.State.Waiting != nil:
+								log.G(ctx).Info("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is setting up on Sidecar")
+								podRunning = true
+							case containerRemoteStatus.State.Running != nil:
+								podRunning = true
+								log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is running on Sidecar")
 							}
-							if podWaitingForInitContainers {
-								podRefInCluster.Status.Phase = v1.PodPending
-								podRefInCluster.Status.Reason = "Waiting for init containers"
+						}
+					}
+					if counterOfTerminatedContainers == nContainersInPod {
+						podCompleted = true
+					}
+
+					if podCompleted {
+						// it means that all containers are terminated, check if some of them are errored
+						if podErrored {
+							podRefInCluster.Status.Phase = v1.PodFailed
+							podRefInCluster.Status.Reason = failedReason
+							// override all the ContainerStatuses to set Reason to failedReason
+							for i := range podRefInCluster.Status.ContainerStatuses {
+								podRefInCluster.Status.ContainerStatuses[i].State.Terminated.Reason = failedReason
 							}
-							if podRunning && podRefInCluster.Status.Phase != v1.PodRunning { // do not update the status if it is already running
-								podRefInCluster.Status.Phase = v1.PodRunning
-								podRefInCluster.Status.Conditions = append(podRefInCluster.Status.Conditions, v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionTrue})
-							}
+						} else {
+							podRefInCluster.Status.Conditions = append(podRefInCluster.Status.Conditions, v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionFalse})
+							podRefInCluster.Status.Phase = v1.PodSucceeded
+							podRefInCluster.Status.Reason = PodPhaseCompleted
 						}
 					} else {
-						list, err := p.clientSet.CoreV1().Pods(podRemoteStatus.PodNamespace).List(ctx, metav1.ListOptions{})
-						if err != nil {
-							log.G(ctx).Error(err)
-							return nil, err
+						if podInit {
+							podRefInCluster.Status.Phase = v1.PodPending
+							podRefInCluster.Status.Reason = "Init"
 						}
+						if podWaitingForInitContainers {
+							podRefInCluster.Status.Phase = v1.PodPending
+							podRefInCluster.Status.Reason = "Waiting for init containers"
+						}
+						if podRunning && podRefInCluster.Status.Phase != v1.PodRunning { // do not update the status if it is already running
+							podRefInCluster.Status.Phase = v1.PodRunning
+							podRefInCluster.Status.Conditions = append(podRefInCluster.Status.Conditions, v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionTrue})
+						}
+					}
+				} else {
+					list, err := p.clientSet.CoreV1().Pods(podRemoteStatus.PodNamespace).List(ctx, metav1.ListOptions{})
+					if err != nil {
+						log.G(ctx).Error(err)
+						return nil, err
+					}
 
-						pods := list.Items
+					pods := list.Items
 
-						for _, pod := range pods {
-							if string(pod.UID) == podRemoteStatus.PodUID {
-								err = updateCacheRequest(ctx, config, pod, token)
-								if err != nil {
-									log.G(ctx).Error(err)
-									continue
-								}
+					for _, pod := range pods {
+						if string(pod.UID) == podRemoteStatus.PodUID {
+							err = updateCacheRequest(ctx, config, pod, token)
+							if err != nil {
+								log.G(ctx).Error(err)
+								continue
 							}
 						}
-
 					}
+
 				}
+
 			}
 			log.G(ctx).Info("No errors while getting statuses")
 			log.G(ctx).Debug(ret)

--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -387,6 +387,11 @@ func LogRetrieval(ctx context.Context, config Config, logsRequest types.LogStruc
 	AddSessionContext(req, sessionContext)
 
 	logTransport := http.DefaultTransport.(*http.Transport).Clone()
+
+	// logTransport.TLSClientConfig = &tls.Config{
+	// 	InsecureSkipVerify: true,
+	// }
+
 	// logTransport.DisableKeepAlives = true
 	// logTransport.MaxIdleConnsPerHost = -1
 	var logHTTPClient = &http.Client{Transport: logTransport}
@@ -539,8 +544,6 @@ func RemoteExecution(ctx context.Context, config Config, p *Provider, pod *v1.Po
 // After the statusRequest returns a response, this function uses that response to update every Pod and Container status.
 func checkPodsStatus(ctx context.Context, p *Provider, podsList []*v1.Pod, token string, config Config) ([]types.PodStatus, error) {
 	var ret []types.PodStatus
-	// commented out because it's too verbose. uncomment to see all registered pods
-	// log.G(ctx).Debug(p.pods)
 
 	// retrieve pod status from remote interlink
 	returnVal, err := statusRequest(ctx, config, podsList, token)
@@ -574,12 +577,71 @@ func checkPodsStatus(ctx context.Context, p *Provider, podsList []*v1.Pod, token
 
 					// if the PodUID match with the one in etcd we are talking of the same thing. GOOD
 					if podRemoteStatus.PodUID == string(podRefInCluster.UID) {
-						podRunning := false
-						podErrored := false
-						podCompleted := false
+						podInit := false                     // if a init container is running, the other containers phase is PodInitializing
+						podRunning := false                  // if a normale container is running, the phase is PodRunning
+						podErrored := false                  // if a container is in error, the phase is PodFailed
+						podCompleted := false                // if all containers are terminated, the phase is PodSucceeded, but if one is in error, the phase is PodFailed
+						podWaitingForInitContainers := false // if init containers are waiting, the phase is PodPending
 						failedReason := ""
 
-						// For each container of the pod we check if there is a previous state known by K8s
+						nContainersInPod := len(podRemoteStatus.Containers)
+						counterOfTerminatedContainers := 0
+
+						nInitContainersInPod := len(podRemoteStatus.InitContainers)
+						counterOfTerminatedInitContainers := 0
+
+						log.G(ctx).Debug("Number of containers in POD:      " + strconv.Itoa(nContainersInPod))
+						log.G(ctx).Debug("Number of init containers in POD: " + strconv.Itoa(nContainersInPod))
+
+						// if there are init containers, we need to check them first
+						if nInitContainersInPod > 0 {
+
+							log.G(ctx).Debug("Init containers detected, going to check them first")
+
+							for _, containerRemoteStatus := range podRemoteStatus.InitContainers {
+								index := 0
+								foundCt := false
+
+								for i, checkedContainer := range podRefInCluster.Status.InitContainerStatuses {
+									if checkedContainer.Name == containerRemoteStatus.Name {
+										foundCt = true
+										index = i
+									}
+								}
+
+								if !foundCt {
+									podRefInCluster.Status.InitContainerStatuses = append(podRefInCluster.Status.InitContainerStatuses, containerRemoteStatus)
+								} else {
+									podRefInCluster.Status.InitContainerStatuses[index] = containerRemoteStatus
+								}
+
+								switch {
+								case containerRemoteStatus.State.Terminated != nil:
+									counterOfTerminatedInitContainers = counterOfTerminatedInitContainers + 1
+									podRefInCluster.Status.InitContainerStatuses[index].State.Terminated.ExitCode = containerRemoteStatus.State.Terminated.ExitCode
+									podRefInCluster.Status.InitContainerStatuses[index].State.Terminated.Reason = "Completed"
+									if containerRemoteStatus.State.Terminated.ExitCode != 0 {
+										podErrored = true
+										failedReason = "Error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode))
+										podRefInCluster.Status.InitContainerStatuses[index].State.Terminated.Reason = failedReason
+										log.G(ctx).Error("Container " + containerRemoteStatus.Name + " exited with error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode)))
+									}
+								case containerRemoteStatus.State.Waiting != nil:
+									log.G(ctx).Info("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is setting up on Sidecar")
+									podWaitingForInitContainers = true
+									podRefInCluster.Status.InitContainerStatuses[index].State.Waiting = containerRemoteStatus.State.Waiting
+								case containerRemoteStatus.State.Running != nil:
+									podInit = true
+									log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is running on Sidecar")
+									podRefInCluster.Status.InitContainerStatuses[index].State.Running = containerRemoteStatus.State.Running
+									podRefInCluster.Status.InitContainerStatuses[index].State.Waiting = nil
+								}
+							}
+							if counterOfTerminatedInitContainers == nInitContainersInPod {
+								podWaitingForInitContainers = false
+							}
+						}
+
 						for _, containerRemoteStatus := range podRemoteStatus.Containers {
 							index := 0
 							foundCt := false
@@ -598,47 +660,73 @@ func checkPodsStatus(ctx context.Context, p *Provider, podsList []*v1.Pod, token
 								podRefInCluster.Status.ContainerStatuses[index] = containerRemoteStatus
 							}
 
-							log.G(ctx).Debug(containerRemoteStatus.State.Running)
-
-							// if plugin cannot return any non-terminated container set the status to terminated
-							// if the exit code is != 0 get the error  and set error reason + rememeber to set pod to failed
-							switch {
-							case containerRemoteStatus.State.Terminated != nil:
-								log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is not running on Plugin side")
-								podCompleted = true
-								podRefInCluster.Status.ContainerStatuses[index].State.Terminated.Reason = "Completed"
-								if containerRemoteStatus.State.Terminated.ExitCode != 0 {
-									podErrored = true
-									failedReason = "Error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode))
-									podRefInCluster.Status.ContainerStatuses[index].State.Terminated.Reason = failedReason
-									log.G(ctx).Error("Container " + containerRemoteStatus.Name + " exited with error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode)))
+							// if the pod is waiting for the starting of the init containers or some of them are still running
+							// all the other containers are in waiting state
+							if podWaitingForInitContainers || podInit {
+								podRefInCluster.Status.ContainerStatuses[index].State.Waiting = &v1.ContainerStateWaiting{Reason: "Waiting for init containers"}
+								podRefInCluster.Status.ContainerStatuses[index].State.Running = nil
+								podRefInCluster.Status.ContainerStatuses[index].State.Terminated = nil
+								if podInit {
+									podRefInCluster.Status.ContainerStatuses[index].State.Waiting.Reason = "Init:" + strconv.Itoa(counterOfTerminatedInitContainers) + "/" + strconv.Itoa(nInitContainersInPod)
+								} else {
+									podRefInCluster.Status.ContainerStatuses[index].State.Waiting.Reason = "PodInitializing"
 								}
-							case containerRemoteStatus.State.Waiting != nil:
-								log.G(ctx).Info("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is setting up on Sidecar")
-								podRunning = true
-							case containerRemoteStatus.State.Running != nil:
-								podRunning = true
-								log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is running on Sidecar")
+							} else {
+								// if plugin cannot return any non-terminated container set the status to terminated
+								// if the exit code is != 0 get the error  and set error reason + rememeber to set pod to failed
+								switch {
+								case containerRemoteStatus.State.Terminated != nil:
+									log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is not running on Plugin side")
+									counterOfTerminatedContainers = counterOfTerminatedContainers + 1
+									podRefInCluster.Status.ContainerStatuses[index].State.Terminated.Reason = "Completed"
+									if containerRemoteStatus.State.Terminated.ExitCode != 0 {
+										podErrored = true
+										failedReason = "Error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode))
+										podRefInCluster.Status.ContainerStatuses[index].State.Terminated.Reason = failedReason
+										log.G(ctx).Error("Container " + containerRemoteStatus.Name + " exited with error: " + strconv.Itoa(int(containerRemoteStatus.State.Terminated.ExitCode)))
+									}
+								case containerRemoteStatus.State.Waiting != nil:
+									log.G(ctx).Info("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is setting up on Sidecar")
+									podRunning = true
+								case containerRemoteStatus.State.Running != nil:
+									podRunning = true
+									log.G(ctx).Debug("Pod " + podRemoteStatus.PodName + ": Service " + containerRemoteStatus.Name + " is running on Sidecar")
+								}
 							}
+						}
+						if counterOfTerminatedContainers == nContainersInPod {
+							podCompleted = true
+						}
 
-							// if this is the first time you see a container running/errored/completed, update the status of the pod.
-							switch {
-							case podRunning && podRefInCluster.Status.Phase != v1.PodRunning:
-								podRefInCluster.Status.Phase = v1.PodRunning
-								podRefInCluster.Status.Conditions = append(podRefInCluster.Status.Conditions, v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionTrue})
-							case podErrored && podRefInCluster.Status.Phase != v1.PodFailed:
+						if podCompleted {
+							// it means that all containers are terminated, check if some of them are errored
+							if podErrored {
 								podRefInCluster.Status.Phase = v1.PodFailed
 								podRefInCluster.Status.Reason = failedReason
-							case podCompleted && podRefInCluster.Status.Phase != v1.PodSucceeded:
+								// override all the ContainerStatuses to set Reason to failedReason
+								for i := range podRefInCluster.Status.ContainerStatuses {
+									podRefInCluster.Status.ContainerStatuses[i].State.Terminated.Reason = failedReason
+								}
+							} else {
 								podRefInCluster.Status.Conditions = append(podRefInCluster.Status.Conditions, v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionFalse})
 								podRefInCluster.Status.Phase = v1.PodSucceeded
 								podRefInCluster.Status.Reason = "Completed"
 							}
-
+						} else {
+							if podInit {
+								podRefInCluster.Status.Phase = v1.PodPending
+								podRefInCluster.Status.Reason = "Init"
+							}
+							if podWaitingForInitContainers {
+								podRefInCluster.Status.Phase = v1.PodPending
+								podRefInCluster.Status.Reason = "Waiting for init containers"
+							}
+							if podRunning && podRefInCluster.Status.Phase != v1.PodRunning { // do not update the status if it is already running
+								podRefInCluster.Status.Phase = v1.PodRunning
+								podRefInCluster.Status.Conditions = append(podRefInCluster.Status.Conditions, v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionTrue})
+							}
 						}
 					} else {
-
-						// if you don't now any UID yet, collect the status and updated the status cache
 						list, err := p.clientSet.CoreV1().Pods(podRemoteStatus.PodNamespace).List(ctx, metav1.ListOptions{})
 						if err != nil {
 							log.G(ctx).Error(err)


### PR DESCRIPTION
#### Description

Updated handling of container statuses and introduces better support for init containers in the system.

#### Key Changes  
1. **Preserve Failed Container Status**  
   - Successful containers no longer overwrite the status of failed containers, ensuring accurate state reporting.  

2. **Improved Init Container Handling**  
   - If a pod includes init containers, the system now verifies their completion before proceeding to the main containers.  
   - On the plugin side, init containers should be correctly handled:  
     - Executed sequentially in the defined order.  
     - Must complete before starting the main containers.  

These changes ensure a more robust and predictable behavior for pods with complex container setups, aligning the implementation with expected Kubernetes standards.  

#### Testing
To validate the new changes, testing was conducted using a setup that includes a Virtual Kubelet (VK) deployed in a Kubernetes (k8s) cluster created with kind, an InterLink API server running behind an OAuth proxy on an edge node alongside the Docker plugin.

1. Tests from the suite available in this repo https://github.com/interTwin-eu/vk-test-set have been successful executed.
```
========================================================================== test session starts ==========================================================================
platform linux -- Python 3.10.12, pytest-8.2.0, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/giulio/vk-setup/vk-test-set
configfile: pyproject.toml
plugins: typeguard-4.3.0
collected 10 items                                                                                                                                                      

vktestset/basic_test.py::test_namespace_exists[interlink] PASSED                                                                                                  [ 10%]
vktestset/basic_test.py::test_node_exists[virtual-node] PASSED                                                                                                    [ 20%]
vktestset/basic_test.py::test_manifest[virtual-node-000-hello-world.yaml] PASSED                                                                                  [ 30%]
vktestset/basic_test.py::test_manifest[virtual-node-010-simple-python.yaml] PASSED                                                                                [ 40%]
vktestset/basic_test.py::test_manifest[virtual-node-020-python-env.yaml] PASSED                                                                                   [ 50%]
vktestset/basic_test.py::test_manifest[virtual-node-030-simple-shared-volume.yaml] PASSED                                                                         [ 60%]
vktestset/basic_test.py::test_manifest[virtual-node-040-config-volumes.yaml] PASSED                                                                               [ 70%]
vktestset/basic_test.py::test_manifest[virtual-node-050-limits.yaml] PASSED                                                                                       [ 80%]
vktestset/basic_test.py::test_manifest[virtual-node-060-init-container.yaml] PASSED                                                                               [ 90%]
vktestset/basic_test.py::test_manifest[virtual-node-070-rclone-bind.yaml] PASSED                                                                                  [100%]

==================================================================== 10 passed in 120.25s (0:02:00) =====================================================================
```
2. A POD with multiple init containers and multiple containers has been tested by also varying the order of the failed and successful containers
```
apiVersion: v1
kind: Pod
metadata:
  name: hello-world-1
  namespace: interlink

spec:
  restartPolicy: Never
  nodeSelector:
    kubernetes.io/hostname: virtual-node

  initContainers:
  - name: init-cnt1
    image: ghcr.io/grycap/cowsay
    command: ["/bin/sh", "-c"]
    args: ["echo 'init cnt 1. now sleep'; sleep 5; exit 0"]
    imagePullPolicy: Always

  - name: init-cnt2
    image: ghcr.io/grycap/cowsay
    command: ["/bin/sh", "-c"]
    args: ["echo 'init cnt 2. now sleep'; sleep 5; exit 0"]
    imagePullPolicy: Always

  containers:
  - name: successful-container
    image: busybox
    command: ["/bin/sh", "-c"]
    args: ["exit 0"]
    imagePullPolicy: Always

  - name: hello-world
    image: ghcr.io/grycap/cowsay
    command: ["/bin/sh", "-c"]
    args: ["echo 'hello world'; sleep 5"]
    imagePullPolicy: Always

  - name: fail-container
    image: busybox
    command: ["/bin/sh", "-c"]
    args: ["exit 1"]  # FORCE FAIL EXIT CODE
    imagePullPolicy: Always

  dnsPolicy: ClusterFirst

  tolerations:
    - key: virtual-node.interlink/no-schedule
      operator: Exists
      effect: NoSchedule
 ```
