### PR TITLE
341 enable defining additional custom taints and labels to virtual nodes from interlink config

### DIFF
--- a/ci/manifests/interlink-config-local.yaml
+++ b/ci/manifests/interlink-config-local.yaml
@@ -6,11 +6,11 @@
 # data:
 #   InterLinkConfig.yaml: |
     #InterlinkAddress: "unix:///var/run/interlink.socket"
-InterlinkAddress: "http://0.0.0.0"
-InterlinkPort: "3000"
-#SidecarURL: "http://plugin"
-SidecarURL: "http://0.0.0.0"
-SidecarPort: "4000"
-VerboseLogging: true
-ErrorsOnlyLogging: false
-DataRootFolder: "~/.interlink"
+interlinkAddress: "http://0.0.0.0"
+interlinkPort: "3000"
+#sidecarURL: "http://plugin"
+sidecarURL: "http://0.0.0.0"
+sidecarPort: "4000"
+verboseLogging: true
+errorsOnlyLogging: false
+dataRootFolder: "~/.interlink"

--- a/ci/manifests/interlink-config-local.yaml
+++ b/ci/manifests/interlink-config-local.yaml
@@ -6,11 +6,11 @@
 # data:
 #   InterLinkConfig.yaml: |
     #InterlinkAddress: "unix:///var/run/interlink.socket"
-interlinkAddress: "http://0.0.0.0"
-interlinkPort: "3000"
+InterlinkAddress: "http://0.0.0.0"
+InterlinkPort: "3000"
 #sidecarURL: "http://plugin"
-sidecarURL: "http://0.0.0.0"
-sidecarPort: "4000"
-verboseLogging: true
-errorsOnlyLogging: false
-dataRootFolder: "~/.interlink"
+SidecarURL: "http://0.0.0.0"
+SidecarPort: "4000"
+VerboseLogging: true
+ErrorsOnlyLogging: false
+DataRootFolder: "~/.interlink"

--- a/ci/manifests/interlink-config.yaml
+++ b/ci/manifests/interlink-config.yaml
@@ -6,11 +6,11 @@
 # data:
 #   InterLinkConfig.yaml: |
     #InterlinkAddress: "unix:///var/run/interlink.socket"
-interlinkAddress: "http://0.0.0.0"
-interlinkPort: "3000"
-sidecarURL: "http://plugin"
+InterlinkAddress: "http://0.0.0.0"
+InterlinkPort: "3000"
+SidecarURL: "http://plugin"
 #sidecarURL: "http://0.0.0.0"
-sidecarPort: "4000"
-verboseLogging: true
-errorsOnlyLogging: false
-dataRootFolder: "~/.interlink"
+SidecarPort: "4000"
+VerboseLogging: true
+ErrorsOnlyLogging: false
+DataRootFolder: "~/.interlink"

--- a/ci/manifests/interlink-config.yaml
+++ b/ci/manifests/interlink-config.yaml
@@ -6,11 +6,11 @@
 # data:
 #   InterLinkConfig.yaml: |
     #InterlinkAddress: "unix:///var/run/interlink.socket"
-InterlinkAddress: "http://0.0.0.0"
-InterlinkPort: "3000"
-SidecarURL: "http://plugin"
-#SidecarURL: "http://0.0.0.0"
-SidecarPort: "4000"
-VerboseLogging: true
-ErrorsOnlyLogging: false
-DataRootFolder: "~/.interlink"
+interlinkAddress: "http://0.0.0.0"
+interlinkPort: "3000"
+sidecarURL: "http://plugin"
+#sidecarURL: "http://0.0.0.0"
+sidecarPort: "4000"
+verboseLogging: true
+errorsOnlyLogging: false
+dataRootFolder: "~/.interlink"

--- a/ci/manifests/virtual-kubelet-config.yaml
+++ b/ci/manifests/virtual-kubelet-config.yaml
@@ -13,9 +13,10 @@ data:
     ServiceAccount: "virtual-kubelet"
     Namespace: interlink 
     VKTokenFile: ""
-    CPU: "100"
-    Memory: "128Gi"
-    Pods: "100"
+    Resources:
+      CPU: "100"
+      Memory: "128Gi"
+      Pods: "100"
     HTTP:
       Insecure: true
     KubeletHTTP:

--- a/ci/manifests/virtual-kubelet-config.yaml
+++ b/ci/manifests/virtual-kubelet-config.yaml
@@ -6,18 +6,18 @@ metadata:
 data:
   InterLinkConfig.yaml: |
     #InterlinkURL: unix:///var/run/interlink.socket
-    InterlinkURL: "http://interlink"
-    InterlinkPort: "3000" 
-    VerboseLogging: true
-    ErrorsOnlyLogging: false
-    ServiceAccount: "virtual-kubelet"
-    Namespace: interlink 
-    VKTokenFile: ""
-    CPU: "100"
-    Memory: "128Gi"
-    Pods: "100"
+    interlinkURL: "http://interlink"
+    interlinkPort: "3000" 
+    verboseLogging: true
+    errorsOnlyLogging: false
+    serviceAccount: "virtual-kubelet"
+    namespace: interlink 
+    vKTokenFile: ""
+    cpu: "100"
+    memory: "128Gi"
+    pods: "100"
     HTTP:
       Insecure: true
-    KubeletHTTP:
+    kubeletHTTP:
       Insecure: true
 

--- a/ci/manifests/virtual-kubelet-config.yaml
+++ b/ci/manifests/virtual-kubelet-config.yaml
@@ -6,18 +6,18 @@ metadata:
 data:
   InterLinkConfig.yaml: |
     #InterlinkURL: unix:///var/run/interlink.socket
-    interlinkURL: "http://interlink"
-    interlinkPort: "3000" 
-    verboseLogging: true
-    errorsOnlyLogging: false
-    serviceAccount: "virtual-kubelet"
-    namespace: interlink 
-    vKTokenFile: ""
-    cpu: "100"
-    memory: "128Gi"
-    pods: "100"
+    InterlinkURL: "http://interlink"
+    InterlinkPort: "3000" 
+    VerboseLogging: true
+    ErrorsOnlyLogging: false
+    ServiceAccount: "virtual-kubelet"
+    Namespace: interlink 
+    VKTokenFile: ""
+    CPU: "100"
+    Memory: "128Gi"
+    Pods: "100"
     HTTP:
       Insecure: true
-    kubeletHTTP:
+    KubeletHTTP:
       Insecure: true
 

--- a/cmd/installer/templates/values.yaml
+++ b/cmd/installer/templates/values.yaml
@@ -5,9 +5,10 @@ interlink:
   port: {{.InterLinkPort}}
 
 virtualNode:
-  CPUs: {{.VKLimits.CPU}}
-  MemGiB: {{.VKLimits.Memory}}
-  Pods: {{.VKLimits.Pods}}
+  Resources:
+    CPU: {{.VKLimits.CPU}}
+    Memory: {{.VKLimits.Memory}}
+    Pods: {{.VKLimits.Pods}}
   HTTPProxies:
     HTTP: null
     HTTPs: null

--- a/pkg/interlink/config.go
+++ b/pkg/interlink/config.go
@@ -26,13 +26,13 @@ import (
 
 // Config holds the whole configuration
 type Config struct {
-	InterlinkAddress  string `yaml:"interlinkAddress"`
-	Interlinkport     string `yaml:"interlinkPort"`
-	Sidecarurl        string `yaml:"sidecarURL"`
-	Sidecarport       string `yaml:"sidecarPort"`
-	VerboseLogging    bool   `yaml:"verboseLogging"`
-	ErrorsOnlyLogging bool   `yaml:"errorsOnlyLogging"`
-	DataRootFolder    string `yaml:"dataRootFolder"`
+	InterlinkAddress  string `yaml:"InterlinkAddress"`
+	Interlinkport     string `yaml:"InterlinkPort"`
+	Sidecarurl        string `yaml:"SidecarURL"`
+	Sidecarport       string `yaml:"SidecarPort"`
+	VerboseLogging    bool   `yaml:"VerboseLogging"`
+	ErrorsOnlyLogging bool   `yaml:"ErrorsOnlyLogging"`
+	DataRootFolder    string `yaml:"DataRootFolder"`
 }
 
 func SetupTelemetry(ctx context.Context) (*sdktrace.TracerProvider, error) {

--- a/pkg/interlink/config.go
+++ b/pkg/interlink/config.go
@@ -26,13 +26,13 @@ import (
 
 // Config holds the whole configuration
 type Config struct {
-	InterlinkAddress  string `yaml:"InterlinkAddress"`
-	Interlinkport     string `yaml:"InterlinkPort"`
-	Sidecarurl        string `yaml:"SidecarURL"`
-	Sidecarport       string `yaml:"SidecarPort"`
-	VerboseLogging    bool   `yaml:"VerboseLogging"`
-	ErrorsOnlyLogging bool   `yaml:"ErrorsOnlyLogging"`
-	DataRootFolder    string `yaml:"DataRootFolder"`
+	InterlinkAddress  string `yaml:"interlinkAddress"`
+	Interlinkport     string `yaml:"interlinkPort"`
+	Sidecarurl        string `yaml:"sidecarURL"`
+	Sidecarport       string `yaml:"sidecarPort"`
+	VerboseLogging    bool   `yaml:"verboseLogging"`
+	ErrorsOnlyLogging bool   `yaml:"errorsOnlyLogging"`
+	DataRootFolder    string `yaml:"dataRootFolder"`
 }
 
 func SetupTelemetry(ctx context.Context) (*sdktrace.TracerProvider, error) {

--- a/pkg/virtualkubelet/config.go
+++ b/pkg/virtualkubelet/config.go
@@ -2,41 +2,41 @@ package virtualkubelet
 
 // Config holds the whole configuration
 type Config struct {
-	InterlinkURL      string      `yaml:"interlinkURL"`
-	InterlinkPort     string      `yaml:"interlinkPort"`
-	VKConfigPath      string      `yaml:"vkConfigPath"`
-	VKTokenFile       string      `yaml:"vkTokenFile"`
-	ServiceAccount    string      `yaml:"serviceAccount"`
-	Namespace         string      `yaml:"namespace"`
-	PodIP             string      `yaml:"podIP"`
-	VerboseLogging    bool        `yaml:"verboseLogging"`
-	ErrorsOnlyLogging bool        `yaml:"errorsOnlyLogging"`
-	HTTP              HTTP        `yaml:"http"`
-	KubeletHTTP       HTTP        `yaml:"kubeletHTTP"`
-	Resources         Resources   `yaml:"resources"`
-	NodeLabels        []string    `yaml:"nodeLabels"`
-	NodeTaints        []TaintSpec `yaml:"nodeTaints"`
+	InterlinkURL      string      `yaml:"InterlinkURL"`
+	InterlinkPort     string      `yaml:"InterlinkPort"`
+	VKConfigPath      string      `yaml:"VKConfigPath"`
+	VKTokenFile       string      `yaml:"VKTokenFile"`
+	ServiceAccount    string      `yaml:"ServiceAccount"`
+	Namespace         string      `yaml:"Namespace"`
+	PodIP             string      `yaml:"PodIP"`
+	VerboseLogging    bool        `yaml:"VerboseLogging"`
+	ErrorsOnlyLogging bool        `yaml:"ErrorsOnlyLogging"`
+	HTTP              HTTP        `yaml:"HTTP"`
+	KubeletHTTP       HTTP        `yaml:"KubeletHTTP"`
+	Resources         Resources   `yaml:"Resources"`
+	NodeLabels        []string    `yaml:"NodeLabels"`
+	NodeTaints        []TaintSpec `yaml:"NodeTaints"`
 }
 
 type HTTP struct {
-	Insecure bool `yaml:"insecure"`
+	Insecure bool `yaml:"Insecure"`
 }
 
 type Resources struct {
-	CPU          string        `yaml:"cpu,omitempty"`
-	Memory       string        `yaml:"memory,omitempty"`
-	Pods         string        `yaml:"pods,omitempty"`
-	Accelerators []Accelerator `yaml:"accelerators"`
+	CPU          string        `yaml:"CPU,omitempty"`
+	Memory       string        `yaml:"Memory,omitempty"`
+	Pods         string        `yaml:"Pods,omitempty"`
+	Accelerators []Accelerator `yaml:"Accelerators"`
 }
 
 type Accelerator struct {
-	ResourceType string `yaml:"resource_type"`
-	Model        string `yaml:"model"`
-	Available    int    `yaml:"available"`
+	ResourceType string `yaml:"ResourceType"`
+	Model        string `yaml:"Model"`
+	Available    int    `yaml:"Available"`
 }
 
 type TaintSpec struct {
-	Key    string `yaml:"key"`
-	Value  string `yaml:"value"`
-	Effect string `yaml:"effect"`
+	Key    string `yaml:"Key"`
+	Value  string `yaml:"Value"`
+	Effect string `yaml:"Effect"`
 }

--- a/pkg/virtualkubelet/config.go
+++ b/pkg/virtualkubelet/config.go
@@ -21,27 +21,22 @@ type Config struct {
 type HTTP struct {
 	Insecure bool `yaml:"insecure"`
 }
+
 type Resources struct {
-	CPU    string `yaml:"cpu,omitempty"`
-	Memory string `yaml:"memory,omitempty"`
-	Pods   string `yaml:"pods,omitempty"`
-	GPU    GPU    `yaml:"gpu,omitempty"`
-	FPGA   FPGA   `yaml:"fpga,omitempty"`
+	CPU          string        `yaml:"cpu,omitempty"`
+	Memory       string        `yaml:"memory,omitempty"`
+	Pods         string        `yaml:"pods,omitempty"`
+	Accelerators []Accelerator `yaml:"accelerators"`
 }
 
-type GPU struct {
-	Nvidia string `yaml:"nvidia,omitempty"`
-	AMD    string `yaml:"amd,omitempty"`
-	Intel  string `yaml:"intel,omitempty"`
-}
-
-type FPGA struct {
-	Xilinx string `yaml:"xilinx,omitempty"`
-	Intel  string `yaml:"intel,omitempty"`
+type Accelerator struct {
+	ResourceType string `yaml:"resource_type"`
+	Model        string `yaml:"model"`
+	Available    int    `yaml:"available"`
 }
 
 type TaintSpec struct {
 	Key    string `yaml:"key"`
 	Value  string `yaml:"value"`
-	Effect string `yaml:"effect"` // E.g., "NoSchedule"
+	Effect string `yaml:"effect"`
 }

--- a/pkg/virtualkubelet/config.go
+++ b/pkg/virtualkubelet/config.go
@@ -2,40 +2,46 @@ package virtualkubelet
 
 // Config holds the whole configuration
 type Config struct {
-	InterlinkURL      string      `yaml:"InterlinkURL"`
-	InterlinkPort     string      `yaml:"InterlinkPort"`
-	VKConfigPath      string      `yaml:"VKConfigPath"`
-	VKTokenFile       string      `yaml:"VKTokenFile"`
-	ServiceAccount    string      `yaml:"ServiceAccount"`
-	Namespace         string      `yaml:"Namespace"`
-	PodIP             string      `yaml:"PodIP"`
-	VerboseLogging    bool        `yaml:"VerboseLogging"`
-	ErrorsOnlyLogging bool        `yaml:"ErrorsOnlyLogging"`
-	HTTP              HTTP        `yaml:"HTTP"`
-	KubeletHTTP       HTTP        `yaml:"KubeletHTTP"`
-	Resources         Resources   `yaml:"Resources"`
-	NodeLabels        []string    `yaml:"NodeLabels"`
-	NodeTaints        []TaintSpec `yaml:"NodeTaints"`
+	InterlinkURL      string      `yaml:"interlinkURL"`
+	InterlinkPort     string      `yaml:"interlinkPort"`
+	VKConfigPath      string      `yaml:"vkConfigPath"`
+	VKTokenFile       string      `yaml:"vkTokenFile"`
+	ServiceAccount    string      `yaml:"serviceAccount"`
+	Namespace         string      `yaml:"namespace"`
+	PodIP             string      `yaml:"podIP"`
+	VerboseLogging    bool        `yaml:"verboseLogging"`
+	ErrorsOnlyLogging bool        `yaml:"errorsOnlyLogging"`
+	HTTP              HTTP        `yaml:"http"`
+	KubeletHTTP       HTTP        `yaml:"kubeletHTTP"`
+	Resources         Resources   `yaml:"resources"`
+	NodeLabels        []string    `yaml:"nodeLabels"`
+	NodeTaints        []TaintSpec `yaml:"nodeTaints"`
 }
 
-// HTTP contains configuration related to HTTP settings
 type HTTP struct {
-	Insecure bool `yaml:"Insecure"`
+	Insecure bool `yaml:"insecure"`
 }
-
-// Resources groups CPU, Memory, Pods, and GPU resources
 type Resources struct {
-	CPU       string `yaml:"CPU,omitempty"`
-	Memory    string `yaml:"Memory,omitempty"`
-	Pods      string `yaml:"Pods,omitempty"`
-	NvidiaGPU string `yaml:"NvidiaGPU,omitempty"`
-	AMDGPU    string `yaml:"AMDGPU,omitempty"`
-	IntelGPU  string `yaml:"IntelGPU,omitempty"`
+	CPU    string `yaml:"cpu,omitempty"`
+	Memory string `yaml:"memory,omitempty"`
+	Pods   string `yaml:"pods,omitempty"`
+	GPU    GPU    `yaml:"gpu,omitempty"`
+	FPGA   FPGA   `yaml:"fpga,omitempty"`
 }
 
-// TaintSpec represents a node taint with key, value, and effect
+type GPU struct {
+	Nvidia string `yaml:"nvidia,omitempty"`
+	AMD    string `yaml:"amd,omitempty"`
+	Intel  string `yaml:"intel,omitempty"`
+}
+
+type FPGA struct {
+	Xilinx string `yaml:"xilinx,omitempty"`
+	Intel  string `yaml:"intel,omitempty"`
+}
+
 type TaintSpec struct {
-	Key    string `yaml:"Key"`
-	Value  string `yaml:"Value"`
-	Effect string `yaml:"Effect"` // E.g., "NoSchedule"
+	Key    string `yaml:"key"`
+	Value  string `yaml:"value"`
+	Effect string `yaml:"effect"` // E.g., "NoSchedule"
 }

--- a/pkg/virtualkubelet/config.go
+++ b/pkg/virtualkubelet/config.go
@@ -2,24 +2,24 @@ package virtualkubelet
 
 // Config holds the whole configuration
 type Config struct {
-	InterlinkURL       string      `yaml:"InterlinkURL"`
-	InterlinkPort      string      `yaml:"InterlinkPort"`
-	KubernetesAPIAddr  string      `yaml:"KubernetesApiAddr"`
-	KubernetesAPIPort  string      `yaml:"KubernetesApiPort"`
-	KubernetesAPICaCrt string      `yaml:"KubernetesApiCaCrt"`
-	DisableProjectedVolumes bool   `yaml:"DisableProjectedVolumes"`
-	VKConfigPath       string      `yaml:"VKConfigPath"`
-	VKTokenFile        string      `yaml:"VKTokenFile"`
-	ServiceAccount     string      `yaml:"ServiceAccount"`
-	Namespace          string      `yaml:"Namespace"`
-	PodIP              string      `yaml:"PodIP"`
-	VerboseLogging     bool        `yaml:"VerboseLogging"`
-	ErrorsOnlyLogging  bool        `yaml:"ErrorsOnlyLogging"`
-	HTTP               HTTP        `yaml:"HTTP"`
-	KubeletHTTP        HTTP        `yaml:"KubeletHTTP"`
-	Resources          Resources   `yaml:"Resources"`
-	NodeLabels         []string    `yaml:"NodeLabels"`
-	NodeTaints         []TaintSpec `yaml:"NodeTaints"`
+	InterlinkURL            string      `yaml:"InterlinkURL"`
+	InterlinkPort           string      `yaml:"InterlinkPort"`
+	KubernetesAPIAddr       string      `yaml:"KubernetesApiAddr"`
+	KubernetesAPIPort       string      `yaml:"KubernetesApiPort"`
+	KubernetesAPICaCrt      string      `yaml:"KubernetesApiCaCrt"`
+	DisableProjectedVolumes bool        `yaml:"DisableProjectedVolumes"`
+	VKConfigPath            string      `yaml:"VKConfigPath"`
+	VKTokenFile             string      `yaml:"VKTokenFile"`
+	ServiceAccount          string      `yaml:"ServiceAccount"`
+	Namespace               string      `yaml:"Namespace"`
+	PodIP                   string      `yaml:"PodIP"`
+	VerboseLogging          bool        `yaml:"VerboseLogging"`
+	ErrorsOnlyLogging       bool        `yaml:"ErrorsOnlyLogging"`
+	HTTP                    HTTP        `yaml:"HTTP"`
+	KubeletHTTP             HTTP        `yaml:"KubeletHTTP"`
+	Resources               Resources   `yaml:"Resources"`
+	NodeLabels              []string    `yaml:"NodeLabels"`
+	NodeTaints              []TaintSpec `yaml:"NodeTaints"`
 }
 
 type HTTP struct {

--- a/pkg/virtualkubelet/config.go
+++ b/pkg/virtualkubelet/config.go
@@ -2,23 +2,40 @@ package virtualkubelet
 
 // Config holds the whole configuration
 type Config struct {
-	InterlinkURL      string `yaml:"InterlinkURL"`
-	Interlinkport     string `yaml:"InterlinkPort"`
-	VKConfigPath      string `yaml:"VKConfigPath"`
-	VKTokenFile       string `yaml:"VKTokenFile"`
-	ServiceAccount    string `yaml:"ServiceAccount"`
-	Namespace         string `yaml:"Namespace"`
-	PodIP             string `yaml:"PodIP"`
-	VerboseLogging    bool   `yaml:"VerboseLogging"`
-	ErrorsOnlyLogging bool   `yaml:"ErrorsOnlyLogging"`
-	HTTP              HTTP   `yaml:"HTTP"`
-	KubeletHTTP       HTTP   `yaml:"KubeletHTTP"`
-	CPU               string `yaml:"CPU,omitempty"`
-	Memory            string `yaml:"Memory,omitempty"`
-	Pods              string `yaml:"Pods,omitempty"`
-	GPU               string `yaml:"nvidia.com/gpu,omitempty"`
+	InterlinkURL      string      `yaml:"InterlinkURL"`
+	InterlinkPort     string      `yaml:"InterlinkPort"`
+	VKConfigPath      string      `yaml:"VKConfigPath"`
+	VKTokenFile       string      `yaml:"VKTokenFile"`
+	ServiceAccount    string      `yaml:"ServiceAccount"`
+	Namespace         string      `yaml:"Namespace"`
+	PodIP             string      `yaml:"PodIP"`
+	VerboseLogging    bool        `yaml:"VerboseLogging"`
+	ErrorsOnlyLogging bool        `yaml:"ErrorsOnlyLogging"`
+	HTTP              HTTP        `yaml:"HTTP"`
+	KubeletHTTP       HTTP        `yaml:"KubeletHTTP"`
+	Resources         Resources   `yaml:"Resources"`
+	NodeLabels        []string    `yaml:"NodeLabels"`
+	NodeTaints        []TaintSpec `yaml:"NodeTaints"`
 }
 
+// HTTP contains configuration related to HTTP settings
 type HTTP struct {
 	Insecure bool `yaml:"Insecure"`
+}
+
+// Resources groups CPU, Memory, Pods, and GPU resources
+type Resources struct {
+	CPU       string `yaml:"CPU,omitempty"`
+	Memory    string `yaml:"Memory,omitempty"`
+	Pods      string `yaml:"Pods,omitempty"`
+	NvidiaGPU string `yaml:"NvidiaGPU,omitempty"`
+	AMDGPU    string `yaml:"AMDGPU,omitempty"`
+	IntelGPU  string `yaml:"IntelGPU,omitempty"`
+}
+
+// TaintSpec represents a node taint with key, value, and effect
+type TaintSpec struct {
+	Key    string `yaml:"Key"`
+	Value  string `yaml:"Value"`
+	Effect string `yaml:"Effect"` // E.g., "NoSchedule"
 }

--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -85,7 +85,7 @@ func getSidecarEndpoint(ctx context.Context, interLinkURL string, interLinkPort 
 // PingInterLink pings the InterLink API and returns true if there's an answer. The second return value is given by the answer provided by the API.
 func PingInterLink(ctx context.Context, config Config) (bool, int, error) {
 	tracer := otel.Tracer("interlink-service")
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 	log.G(ctx).Info("Pinging: " + interLinkEndpoint + "/pinglink")
 	retVal := -1
 	req, err := http.NewRequest(http.MethodPost, interLinkEndpoint+"/pinglink", nil)
@@ -143,7 +143,7 @@ func updateCacheRequest(ctx context.Context, config Config, pod v1.Pod, token st
 		return err
 	}
 
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 	reader := bytes.NewReader(bodyBytes)
 	req, err := http.NewRequest(http.MethodPost, interLinkEndpoint+"/updateCache", reader)
 	if err != nil {
@@ -181,7 +181,7 @@ func updateCacheRequest(ctx context.Context, config Config, pod v1.Pod, token st
 // Returns the call response expressed in bytes and/or the first encountered error
 func createRequest(ctx context.Context, config Config, pod types.PodCreateRequests, token string) ([]byte, error) {
 	tracer := otel.Tracer("interlink-service")
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 
 	bodyBytes, err := json.Marshal(pod)
 	if err != nil {
@@ -230,7 +230,7 @@ func createRequest(ctx context.Context, config Config, pod types.PodCreateReques
 // deleteRequest performs a REST call to the InterLink API when a Pod is deleted from the VK. It Marshals the standard v1.Pod struct and sends it to InterLink.
 // Returns the call response expressed in bytes and/or the first encountered error
 func deleteRequest(ctx context.Context, config Config, pod *v1.Pod, token string) ([]byte, error) {
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 	var returnValue []byte
 	bodyBytes, err := json.Marshal(pod)
 	if err != nil {
@@ -286,7 +286,7 @@ func deleteRequest(ctx context.Context, config Config, pod *v1.Pod, token string
 func statusRequest(ctx context.Context, config Config, podsList []*v1.Pod, token string) ([]byte, error) {
 	tracer := otel.Tracer("interlink-service")
 
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 
 	bodyBytes, err := json.Marshal(podsList)
 	if err != nil {
@@ -347,7 +347,7 @@ func LogRetrieval(
 	sessionContext string,
 ) (io.ReadCloser, error) {
 	tracer := otel.Tracer("interlink-service")
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 
 	token := ""
 

--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -86,7 +86,7 @@ func getSidecarEndpoint(ctx context.Context, interLinkURL string, interLinkPort 
 // PingInterLink pings the InterLink API and returns true if there's an answer. The second return value is given by the answer provided by the API.
 func PingInterLink(ctx context.Context, config Config) (bool, int, error) {
 	tracer := otel.Tracer("interlink-service")
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 	log.G(ctx).Info("Pinging: " + interLinkEndpoint + "/pinglink")
 	retVal := -1
 	req, err := http.NewRequest(http.MethodPost, interLinkEndpoint+"/pinglink", nil)
@@ -144,7 +144,7 @@ func updateCacheRequest(ctx context.Context, config Config, pod v1.Pod, token st
 		return err
 	}
 
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 	reader := bytes.NewReader(bodyBytes)
 	req, err := http.NewRequest(http.MethodPost, interLinkEndpoint+"/updateCache", reader)
 	if err != nil {
@@ -182,7 +182,7 @@ func updateCacheRequest(ctx context.Context, config Config, pod v1.Pod, token st
 // Returns the call response expressed in bytes and/or the first encountered error
 func createRequest(ctx context.Context, config Config, pod types.PodCreateRequests, token string) ([]byte, error) {
 	tracer := otel.Tracer("interlink-service")
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 
 	bodyBytes, err := json.Marshal(pod)
 	if err != nil {
@@ -231,7 +231,7 @@ func createRequest(ctx context.Context, config Config, pod types.PodCreateReques
 // deleteRequest performs a REST call to the InterLink API when a Pod is deleted from the VK. It Marshals the standard v1.Pod struct and sends it to InterLink.
 // Returns the call response expressed in bytes and/or the first encountered error
 func deleteRequest(ctx context.Context, config Config, pod *v1.Pod, token string) ([]byte, error) {
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 	var returnValue []byte
 	bodyBytes, err := json.Marshal(pod)
 	if err != nil {
@@ -287,7 +287,7 @@ func deleteRequest(ctx context.Context, config Config, pod *v1.Pod, token string
 func statusRequest(ctx context.Context, config Config, podsList []*v1.Pod, token string) ([]byte, error) {
 	tracer := otel.Tracer("interlink-service")
 
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 
 	bodyBytes, err := json.Marshal(podsList)
 	if err != nil {
@@ -348,7 +348,7 @@ func LogRetrieval(
 	sessionContext string,
 ) (io.ReadCloser, error) {
 	tracer := otel.Tracer("interlink-service")
-	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.Interlinkport)
+	interLinkEndpoint := getSidecarEndpoint(ctx, config.InterlinkURL, config.InterlinkPort)
 
 	token := ""
 

--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -229,14 +229,14 @@ func SetDefaultResource(config *Config) {
 	for i, accelerator := range config.Resources.Accelerators {
 		if accelerator.Available == 0 {
 			switch accelerator.ResourceType {
-			case "nvidia.com/gpu", "amd.com/gpu", "intel.com/gpu":
+			case nvidiaGPU, amdGPU, intelGPU:
 				defaultGPUCapacity, err := strconv.Atoi(DefaultGPUCapacity)
 				if err != nil {
 					log.G(context.Background()).Errorf("Invalid default GPU capacity: %v", err)
 					defaultGPUCapacity = 0
 				}
 				config.Resources.Accelerators[i].Available = defaultGPUCapacity
-			case "xilinx.com/fpga", "intel.com/fpga":
+			case xilinxFPGA, intelFPGA:
 				defaultFPGACapacity, err := strconv.Atoi(DefaultFPGACapacity)
 				if err != nil {
 					log.G(context.Background()).Errorf("Invalid default FPGA capacity: %v", err)

--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -40,6 +40,11 @@ const (
 	NameKey               = "name"
 	CREATE                = 0
 	DELETE                = 1
+	nvidiaGPU             = "nvidia.com/gpu"
+	amdGPU                = "amd.com/gpu"
+	intelGPU              = "intel.com/gpu"
+	xilinxFPGA            = "xilinx.com/fpga"
+	intelFPGA             = "intel.com/fpga"
 )
 
 func TracerUpdate(ctx *context.Context, name string, pod *v1.Pod) {
@@ -177,9 +182,9 @@ func GetResources(config Config) v1.ResourceList {
 
 	for _, accelerator := range config.Resources.Accelerators {
 		switch accelerator.ResourceType {
-		case "nvidia.com/gpu", "amd.com/gpu", "intel.com/gpu":
+		case nvidiaGPU, amdGPU, intelGPU:
 			gpuCount[accelerator.ResourceType] += accelerator.Available
-		case "xilinx.com/fpga", "intel.com/fpga":
+		case xilinxFPGA, intelFPGA:
 			fpgaCount[accelerator.ResourceType] += accelerator.Available
 		}
 	}

--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -30,17 +30,16 @@ import (
 )
 
 const (
-	DefaultCPUCapacity       = "100"
-	DefaultMemoryCapacity    = "3000G"
-	DefaultPodCapacity       = "10000"
-	DefaultNvidiaGPUCapacity = "0"
-	DefaultAMDGPUCapacity    = "0"
-	DefaultIntelGPUCapacity  = "0"
-	DefaultListenPort        = 10250
-	NamespaceKey             = "namespace"
-	NameKey                  = "name"
-	CREATE                   = 0
-	DELETE                   = 1
+	DefaultCPUCapacity    = "100"
+	DefaultMemoryCapacity = "3000G"
+	DefaultPodCapacity    = "10000"
+	DefaultGPUCapacity    = "0"
+	DefaultFPGACapacity   = "0"
+	DefaultListenPort     = 10250
+	NamespaceKey          = "namespace"
+	NameKey               = "name"
+	CREATE                = 0
+	DELETE                = 1
 )
 
 func TracerUpdate(ctx *context.Context, name string, pod *v1.Pod) {
@@ -175,12 +174,14 @@ func NodeCondition(ready bool) []v1.NodeCondition {
 func GetResources(config Config) v1.ResourceList {
 
 	return v1.ResourceList{
-		"cpu":            resource.MustParse(config.Resources.CPU),
-		"memory":         resource.MustParse(config.Resources.Memory),
-		"pods":           resource.MustParse(config.Resources.Pods),
-		"nvidia.com/gpu": resource.MustParse(config.Resources.NvidiaGPU),
-		"amd.com/gpu":    resource.MustParse(config.Resources.AMDGPU),
-		"intel.com/gpu":  resource.MustParse(config.Resources.IntelGPU),
+		"cpu":             resource.MustParse(config.Resources.CPU),
+		"memory":          resource.MustParse(config.Resources.Memory),
+		"pods":            resource.MustParse(config.Resources.Pods),
+		"nvidia.com/gpu":  resource.MustParse(config.Resources.GPU.Nvidia),
+		"amd.com/gpu":     resource.MustParse(config.Resources.GPU.AMD),
+		"intel.com/gpu":   resource.MustParse(config.Resources.GPU.Intel),
+		"xilinx.com/fpga": resource.MustParse(config.Resources.FPGA.Xilinx),
+		"intel.com/fpga":  resource.MustParse(config.Resources.FPGA.Intel),
 	}
 
 }
@@ -195,14 +196,20 @@ func SetDefaultResource(config *Config) {
 	if config.Resources.Pods == "" {
 		config.Resources.Pods = DefaultPodCapacity
 	}
-	if config.Resources.NvidiaGPU == "" {
-		config.Resources.NvidiaGPU = DefaultNvidiaGPUCapacity
+	if config.Resources.GPU.Nvidia == "" {
+		config.Resources.GPU.Nvidia = DefaultGPUCapacity
 	}
-	if config.Resources.AMDGPU == "" {
-		config.Resources.AMDGPU = DefaultAMDGPUCapacity
+	if config.Resources.GPU.AMD == "" {
+		config.Resources.GPU.AMD = DefaultGPUCapacity
 	}
-	if config.Resources.IntelGPU == "" {
-		config.Resources.IntelGPU = DefaultIntelGPUCapacity
+	if config.Resources.GPU.Intel == "" {
+		config.Resources.GPU.Intel = DefaultGPUCapacity
+	}
+	if config.Resources.FPGA.Xilinx == "" {
+		config.Resources.FPGA.Xilinx = DefaultFPGACapacity
+	}
+	if config.Resources.FPGA.Intel == "" {
+		config.Resources.FPGA.Intel = DefaultFPGACapacity
 	}
 }
 
@@ -400,14 +407,20 @@ func LoadConfig(ctx context.Context, providerConfig string) (config Config, err 
 	if _, err = resource.ParseQuantity(config.Resources.Pods); err != nil {
 		return config, fmt.Errorf("invalid pods value %v", config.Resources.Pods)
 	}
-	if _, err = resource.ParseQuantity(config.Resources.NvidiaGPU); err != nil {
-		return config, fmt.Errorf("invalid Nvidia GPU value %v", config.Resources.NvidiaGPU)
+	if _, err = resource.ParseQuantity(config.Resources.GPU.Nvidia); err != nil {
+		return config, fmt.Errorf("invalid Nvidia GPU value %v", config.Resources.GPU.Nvidia)
 	}
-	if _, err = resource.ParseQuantity(config.Resources.AMDGPU); err != nil {
-		return config, fmt.Errorf("invalid AMD GPU value %v", config.Resources.AMDGPU)
+	if _, err = resource.ParseQuantity(config.Resources.GPU.AMD); err != nil {
+		return config, fmt.Errorf("invalid AMD GPU value %v", config.Resources.GPU.AMD)
 	}
-	if _, err = resource.ParseQuantity(config.Resources.IntelGPU); err != nil {
-		return config, fmt.Errorf("invalid Intel GPU value %v", config.Resources.IntelGPU)
+	if _, err = resource.ParseQuantity(config.Resources.GPU.Intel); err != nil {
+		return config, fmt.Errorf("invalid Intel GPU value %v", config.Resources.GPU.Intel)
+	}
+	if _, err = resource.ParseQuantity(config.Resources.FPGA.Xilinx); err != nil {
+		return config, fmt.Errorf("invalid Intel FPGA value %v", config.Resources.FPGA.Xilinx)
+	}
+	if _, err = resource.ParseQuantity(config.Resources.FPGA.Intel); err != nil {
+		return config, fmt.Errorf("invalid Xilinx FPGA value %v", config.Resources.FPGA.Intel)
 	}
 
 	return config, nil


### PR DESCRIPTION
## Refactor of the Configuration Structure for VK

This PR introduces improvements and refactoring to the VK configuration structure to enhance clarity, usability, and flexibility.

#### Key Changes:

1. **Refactor of the Configuration Keys**:
   - Configuration keys no longer start with capital letters, ensuring consistency with YAML conventions.
   - Hierarchical structure improved for better organization and readability, particularly within the `resources` section.

2. **Dynamic Handling of Resources**:
   - The new `resources` structure supports dynamic configuration of accelerators such as GPUs and FPGAs.
   - Example configuration:
     ```yaml
     virtualNode:
       resources:
         cpus: 8
         memgib: 49
         pods: 100
         accelerators:
         - resource_type: nvidia.com/gpu
           model: t4
           available: 1
         - resource_type: nvidia.com/gpu
           model: A100
           available: 2
         - resource_type: xilinx.com/fpga
           model: U55C
           available: 1
       nodeLabels:
         - "virtual-kubelet=interlink"
         - "cool-node=true"
       nodeTaints:
         - key: "accelerator"
           value: "A100"
           effect: "NoSchedule"
     ```

3. **Support for Custom Node Labels and Taints**:
   - Additional node labels and taints can now be specified in the configuration.
   - Taints and labels provide flexibility for resource allocation and workload scheduling.

4. **Automatic Node Labeling for Accelerators**:
   - The VK automatically adds labels for accelerators based on the configuration. 
   - Example: If an NVIDIA GPU model A100 is specified, the label `nvidia-gpu-type=a100` is added to the node.

5. **Helm Chart must be updated accordingly**:
   - The Helm chart should be updated accordingly to support the new configuration structure.
   - Example Helm configuration:
     ```yaml
     apiVersion: v1
     kind: ConfigMap
     metadata:
       name: "{{ .Values.nodeName }}-virtual-kubelet-config"
       namespace: {{ .Release.Namespace }}
     data:
       InterLinkConfig.yaml: |
         {{- if .Values.interlink.socket }}
         interlinkURL: {{ .Values.interlink.socket | quote }}
         InterlinkPort: {{ printf "%s-1" .Values.interlink.socket | quote }}
         {{- else }}
         interlinkURL: {{ .Values.interlink.address | quote }}
         interlinkPort: {{ .Values.interlink.port | quote }}
         {{- end }}
         exportPodData: {{ .Values.interlink.exportPodData }}
         verboseLogging: true
         errorsOnlyLogging: false
         serviceAccount: "{{ .Values.nodeName }}"
         namespace: "{{ .Release.Namespace }}"
         vkTokenFile: {{ .Values.OAUTH.enabled | ternary "/opt/interlink/token" "/dev/null" }}
         resources:
           cpu: "{{ .Values.virtualNode.resources.cpus }}"
           memory: "{{ .Values.virtualNode.resources.memgib }}Gi"
           pods: "{{ .Values.virtualNode.resources.pods }}"
           accelerators:
           {{- range .Values.virtualNode.resources.accelerators }}
           - resource_type: "{{ .resource_type }}"
             model: "{{ .model }}"
             available: {{ .available }}
           {{- end }}
         http:
           insecure: {{ .Values.virtualNode.http.insecure }}
         kubeletHTTP:
           insecure: {{ .Values.virtualNode.kubeletHTTP.insecure }}
         nodeLabels:
           {{- range .Values.virtualNode.nodeLabels }}
           - "{{ . }}"
           {{- end }}
         nodeTaints:
           {{- range .Values.virtualNode.nodeTaints }}
           - key: "{{ .key }}"
             value: "{{ .value }}"
             effect: "{{ .effect }}"
           {{- end }}
     ```

---