### PR TITLE
Update installer values.yaml template

### DIFF
--- a/cmd/installer/templates/values.yaml
+++ b/cmd/installer/templates/values.yaml
@@ -4,7 +4,7 @@ interlink:
   
   address: https://{{.InterLinkIP}}
   port: {{.InterLinkPort}}
-  disableProjectedVolumes: true
+  disableProjectedVolumes: false
 
 virtualNode:
   resources:


### PR DESCRIPTION
Default value for 'disableProjectedVolumes' to false, as in https://github.com/interlink-hq/interlink-helm-chart/blob/main/interlink/values.yaml#L21

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

As discussed in Slack, debugging the deployment of edge-node scenario, 'disableProjectedVolumes=true' was causing error. See discussion at https://intertwin.slack.com/archives/C06M04A0LR1/p1746430100785429?thread_ts=1746028429.486859&cid=C06M04A0LR1

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
