### PR TITLE
Fix secret and configmap informer startup

### DIFF
--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -349,11 +349,6 @@ func setupInformers(ctx context.Context, localClient *kubernetes.Clientset, node
 	go podInformerFactory.Start(stopper)
 	go scmInformerFactory.Start(stopper)
 
-	// start to sync and call list
-	if !cache.WaitForCacheSync(stopper, podInformerFactory.Core().V1().Pods().Informer().HasSynced) {
-		log.G(ctx).Fatal(fmt.Errorf("timed out waiting for caches to sync"))
-	}
-
 	return podInformerFactory, scmInformerFactory, stopper
 }
 
@@ -435,6 +430,19 @@ func main() {
 
 	podInformerFactory, scmInformerFactory, stopper := setupInformers(ctx, localClient, cfg.NodeName)
 	defer close(stopper)
+
+	podInformer := podInformerFactory.Core().V1().Pods().Informer()
+	secretInformer := scmInformerFactory.Core().V1().Secrets().Informer()
+	cfgInformer := scmInformerFactory.Core().V1().ConfigMaps().Informer()
+
+	go podInformer.Run(stopper)
+	go secretInformer.Run(stopper)
+	go cfgInformer.Run(stopper)
+
+	// start to sync and call list
+	if !cache.WaitForCacheSync(stopper, podInformerFactory.Core().V1().Pods().Informer().HasSynced) {
+		log.G(ctx).Fatal(fmt.Errorf("timed out waiting for caches to sync"))
+	}
 
 	podControllerConfig := node.PodControllerConfig{
 		PodClient:         localClient.CoreV1(),


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

The regression was a wrong assumption on wheter the informer run command was required or managed by vk internals.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
