### PR TITLE
437 allow configuring skipdownwardapiresolution to enable scheduling pods with downward api

### DIFF
--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -444,7 +444,7 @@ func main() {
 		SecretInformer:            scmInformerFactory.Core().V1().Secrets(),
 		ConfigMapInformer:         scmInformerFactory.Core().V1().ConfigMaps(),
 		ServiceInformer:           scmInformerFactory.Core().V1().Services(),
-		SkipDownwardAPIResolution: interLinkConfig.SkipDownwardAPIResolution,
+		SkipDownwardAPIResolution: interLinkConfig.SkipDownwardAPIResolution, // set to true to skip downward API resolution
 	}
 
 	// // DEBUG

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -437,13 +437,14 @@ func main() {
 	defer close(stopper)
 
 	podControllerConfig := node.PodControllerConfig{
-		PodClient:         localClient.CoreV1(),
-		EventRecorder:     EventRecorder,
-		Provider:          nodeProvider,
-		PodInformer:       podInformerFactory.Core().V1().Pods(),
-		SecretInformer:    scmInformerFactory.Core().V1().Secrets(),
-		ConfigMapInformer: scmInformerFactory.Core().V1().ConfigMaps(),
-		ServiceInformer:   scmInformerFactory.Core().V1().Services(),
+		PodClient:                 localClient.CoreV1(),
+		EventRecorder:             EventRecorder,
+		Provider:                  nodeProvider,
+		PodInformer:               podInformerFactory.Core().V1().Pods(),
+		SecretInformer:            scmInformerFactory.Core().V1().Secrets(),
+		ConfigMapInformer:         scmInformerFactory.Core().V1().ConfigMaps(),
+		ServiceInformer:           scmInformerFactory.Core().V1().Services(),
+		SkipDownwardAPIResolution: interLinkConfig.SkipDownwardAPIResolution,
 	}
 
 	// // DEBUG

--- a/pkg/virtualkubelet/config.go
+++ b/pkg/virtualkubelet/config.go
@@ -2,28 +2,29 @@ package virtualkubelet
 
 // Config holds the whole configuration
 type Config struct {
-	InterlinkURL            string      `yaml:"InterlinkURL"`
-	InterlinkPort           string      `yaml:"InterlinkPort"`
-	KubernetesAPIAddr       string      `yaml:"KubernetesApiAddr"`
-	KubernetesAPIPort       string      `yaml:"KubernetesApiPort"`
-	KubernetesAPICaCrt      string      `yaml:"KubernetesApiCaCrt"`
-	DisableProjectedVolumes bool        `yaml:"DisableProjectedVolumes"`
-	JobScriptBuilderURL     string      `yaml:"JobScriptBuilderURL,omitempty"`
-	VKConfigPath            string      `yaml:"VKConfigPath"`
-	VKTokenFile             string      `yaml:"VKTokenFile"`
-	ServiceAccount          string      `yaml:"ServiceAccount"`
-	Namespace               string      `yaml:"Namespace"`
-	PodIP                   string      `yaml:"PodIP"`
-	PodCIDR                 PodCIDR     `yaml:"PodCIDR"`
-	VerboseLogging          bool        `yaml:"VerboseLogging"`
-	ErrorsOnlyLogging       bool        `yaml:"ErrorsOnlyLogging"`
-	HTTP                    HTTP        `yaml:"HTTP"`
-	KubeletHTTP             HTTP        `yaml:"KubeletHTTP"`
-	Resources               Resources   `yaml:"Resources"`
-	NodeLabels              []string    `yaml:"NodeLabels"`
-	NodeTaints              []TaintSpec `yaml:"NodeTaints"`
-	TLS                     TLSConfig   `yaml:"TLS,omitempty"`
-	Network                 Network     `yaml:"Network,omitempty"`
+	InterlinkURL              string      `yaml:"InterlinkURL"`
+	InterlinkPort             string      `yaml:"InterlinkPort"`
+	KubernetesAPIAddr         string      `yaml:"KubernetesApiAddr"`
+	KubernetesAPIPort         string      `yaml:"KubernetesApiPort"`
+	KubernetesAPICaCrt        string      `yaml:"KubernetesApiCaCrt"`
+	DisableProjectedVolumes   bool        `yaml:"DisableProjectedVolumes"`
+	JobScriptBuilderURL       string      `yaml:"JobScriptBuilderURL,omitempty"`
+	VKConfigPath              string      `yaml:"VKConfigPath"`
+	VKTokenFile               string      `yaml:"VKTokenFile"`
+	ServiceAccount            string      `yaml:"ServiceAccount"`
+	Namespace                 string      `yaml:"Namespace"`
+	PodIP                     string      `yaml:"PodIP"`
+	PodCIDR                   PodCIDR     `yaml:"PodCIDR"`
+	VerboseLogging            bool        `yaml:"VerboseLogging"`
+	ErrorsOnlyLogging         bool        `yaml:"ErrorsOnlyLogging"`
+	HTTP                      HTTP        `yaml:"HTTP"`
+	KubeletHTTP               HTTP        `yaml:"KubeletHTTP"`
+	Resources                 Resources   `yaml:"Resources"`
+	NodeLabels                []string    `yaml:"NodeLabels"`
+	NodeTaints                []TaintSpec `yaml:"NodeTaints"`
+	TLS                       TLSConfig   `yaml:"TLS,omitempty"`
+	Network                   Network     `yaml:"Network,omitempty"`
+	SkipDownwardAPIResolution bool        `yaml:"SkipDownwardAPIResolution,omitempty"`
 }
 
 // TLSConfig holds TLS/mTLS configuration for secure communication with interLink API

--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -815,26 +815,11 @@ func resolveEnvRefs(
 			default:
 				if matches := annotationFieldRefRE.FindStringSubmatch(fr.FieldPath); len(matches) == 2 {
 					annKey := matches[1]
-					if val, ok := pod.Annotations[annKey]; ok {
-						resolved = val
-					} else {
-						log.G(ctx).Warnf("annotation %q not found on pod %s/%s for FieldRef %q (available annotations: %+v)", annKey, pod.Namespace, pod.Name, fr.FieldPath, pod.Annotations)
+					val, ok := pod.Annotations[annKey]
+					if !ok {
 						continue
 					}
-				} else {
-					log.G(ctx).Warnf("unsupported FieldRef %q for env %q, skipping", fr.FieldPath, env.Name)
-					continue
-				}
-			}
-
-			if resolved == "" {
-				log.G(ctx).Warnf("FieldRef %q resolved to empty string for pod %s/%s", fr.FieldPath, pod.Namespace, pod.Name)
-			} else {
-				// Avoid logging potentially sensitive annotation values
-				if matches := annotationFieldRefRE.FindStringSubmatch(fr.FieldPath); len(matches) == 2 {
-					log.G(ctx).Debugf("Resolved FieldRef %q for env %s in pod %s/%s (value omitted for security)", fr.FieldPath, env.Name, pod.Namespace, pod.Name)
-				} else {
-					log.G(ctx).Debugf("Resolved FieldRef %q => %q for env %s in pod %s/%s", fr.FieldPath, resolved, env.Name, pod.Namespace, pod.Name)
+					resolved = val
 				}
 			}
 

--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -830,7 +830,12 @@ func resolveEnvRefs(
 			if resolved == "" {
 				log.G(ctx).Warnf("FieldRef %q resolved to empty string for pod %s/%s", fr.FieldPath, pod.Namespace, pod.Name)
 			} else {
-				log.G(ctx).Debugf("Resolved FieldRef %q => %q for env %s in pod %s/%s", fr.FieldPath, resolved, env.Name, pod.Namespace, pod.Name)
+				// Avoid logging potentially sensitive annotation values
+				if matches := annotationFieldRefRE.FindStringSubmatch(fr.FieldPath); len(matches) == 2 {
+					log.G(ctx).Debugf("Resolved FieldRef %q for env %s in pod %s/%s (value omitted for security)", fr.FieldPath, env.Name, pod.Namespace, pod.Name)
+				} else {
+					log.G(ctx).Debugf("Resolved FieldRef %q => %q for env %s in pod %s/%s", fr.FieldPath, resolved, env.Name, pod.Namespace, pod.Name)
+				}
 			}
 
 			container.Env[i].Value = resolved

--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -945,11 +945,14 @@ func RemoteExecution(ctx context.Context, config Config, p *Provider, pod *v1.Po
 		// Adds special Kubernetes env var. Note: the pod provided by VK is "immutable", well it is a copy. In InterLink, we can modify it.
 		addKubernetesServicesEnvVars(ctx, config, pod)
 
-		for i := range pod.Spec.InitContainers {
-			resolveEnvRefs(ctx, p, pod, &pod.Spec.InitContainers[i])
-		}
-		for i := range pod.Spec.Containers {
-			resolveEnvRefs(ctx, p, pod, &pod.Spec.Containers[i])
+		if config.SkipDownwardAPIResolution == true {
+			log.G(ctx).Info("SkipDownwardAPIResolution is set to true")
+			for i := range pod.Spec.InitContainers {
+				resolveEnvRefs(ctx, p, pod, &pod.Spec.InitContainers[i])
+			}
+			for i := range pod.Spec.Containers {
+				resolveEnvRefs(ctx, p, pod, &pod.Spec.Containers[i])
+			}
 		}
 
 		// For debugging purpose only.

--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -950,7 +950,7 @@ func RemoteExecution(ctx context.Context, config Config, p *Provider, pod *v1.Po
 		// Adds special Kubernetes env var. Note: the pod provided by VK is "immutable", well it is a copy. In InterLink, we can modify it.
 		addKubernetesServicesEnvVars(ctx, config, pod)
 
-		if config.SkipDownwardAPIResolution == true {
+		if config.SkipDownwardAPIResolution {
 			log.G(ctx).Info("SkipDownwardAPIResolution is set to true")
 			for i := range pod.Spec.InitContainers {
 				resolveEnvRefs(ctx, p, pod, &pod.Spec.InitContainers[i])


### PR DESCRIPTION
Enhance resolveEnvRefs to inline env.valueFrom references before sending pods to the remote execution path.
Key changes:
- Added handling for standard FieldRef paths: metadata.name, metadata.namespace, metadata.uid, and status.podIP.
- Introduced safeString fallback to tolerate missing/misaligned metadata by falling back to alternate object fields.
- Implemented resolution for ConfigMapKeyRef and ResourceFieldRef (e.g., requests.cpu, limits.memory) in addition to existing SecretKeyRef.

Tested with the following pods:
```
apiVersion: v1
kind: Secret
metadata:
  name: test-secret
data:
  testfile: dmFsdWUtMg0KDQo=
---
apiVersion: v1
kind: Pod
metadata:
  name: helloworld-pod
spec:
  containers:
  - name: helloworld
    image: busybox:latest
    command:
      - "/bin/sh"
      - "-c"
      - |
        echo "Pod IP is: $SERVING_POD_IP"
        echo "Secret value is: $SECRET_VALUE"
    env:
      - name: SERVING_POD_IP
        valueFrom:
          fieldRef:
            fieldPath: status.podIP
      - name: SECRET_VALUE
        valueFrom:
          secretKeyRef:
            name: test-secret
            key: testfile
    resources:
      requests:
        memory: "4Gi"
        cpu: "2"
      limits:
        memory: "8Gi"
        cpu: "4"
  nodeSelector:
    kubernetes.io/hostname: virtual-node
  tolerations:
    - key: virtual-node.interlink/no-schedule
      operator: Exists
    - effect: NoExecute
      key: node.kubernetes.io/unreachable
      operator: Exists
  ```
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-configmap
data:
  cfgkey: cfgvalue
---
apiVersion: v1
kind: Pod
metadata:
  name: configmap-pod
spec:
  containers:
  - name: helloworld
    image: busybox:latest
    command:
      - "/bin/sh"
      - "-c"
      - |
        echo "ConfigMap value is: $CM_VAL"
    env:
      - name: CM_VAL
        valueFrom:
          configMapKeyRef:
            name: test-configmap
            key: cfgkey
    resources:
      requests:
        memory: "4Gi"
        cpu: "2"
      limits:
        memory: "8Gi"
        cpu: "4"
  nodeSelector:
    kubernetes.io/hostname: virtual-node
  tolerations:
    - key: virtual-node.interlink/no-schedule
      operator: Exists
    - effect: NoExecute
      key: node.kubernetes.io/unreachable
      operator: Exists
 ```
 
 ```
 apiVersion: v1
kind: Pod
metadata:
  name: metadata-pod
spec:
  containers:
  - name: helloworld
    image: busybox:latest
    command:
      - "/bin/sh"
      - "-c"
      - |
        echo "Name: $POD_NAME"
        echo "Namespace: $POD_NAMESPACE"
        echo "UID: $POD_UID"
    env:
      - name: POD_NAME
        valueFrom:
          fieldRef:
            fieldPath: metadata.name
      - name: POD_NAMESPACE
        valueFrom:
          fieldRef:
            fieldPath: metadata.namespace
      - name: POD_UID
        valueFrom:
          fieldRef:
            fieldPath: metadata.uid
    resources:
      requests:
        memory: "4Gi"
        cpu: "2"
      limits:
        memory: "8Gi"
        cpu: "4"
  nodeSelector:
    kubernetes.io/hostname: virtual-node
  tolerations:
    - key: virtual-node.interlink/no-schedule
      operator: Exists
    - effect: NoExecute
      key: node.kubernetes.io/unreachable
      operator: Exists
 ```
 ```
 apiVersion: v1
kind: Pod
metadata:
  name: resource-pod
spec:
  containers:
  - name: helloworld
    image: busybox:latest
    command:
      - "/bin/sh"
      - "-c"
      - |
        echo "Requested CPU: $REQ_CPU"
        echo "Limit Memory: $LIM_MEM"
    env:
      - name: REQ_CPU
        valueFrom:
          resourceFieldRef:
            resource: requests.cpu
      - name: LIM_MEM
        valueFrom:
          resourceFieldRef:
            resource: limits.memory
    resources:
      requests:
        memory: "4Gi"
        cpu: "2"
      limits:
        memory: "8Gi"
        cpu: "4"
  nodeSelector:
    kubernetes.io/hostname: virtual-node
  tolerations:
    - key: virtual-node.interlink/no-schedule
      operator: Exists
    - effect: NoExecute
      key: node.kubernetes.io/unreachable
      operator: Exists
 ```