### PR TITLE
Fix wstunnel resource cleanup inconsistency

### DIFF
--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -1391,11 +1391,9 @@ func (p *Provider) DeletePod(ctx context.Context, pod *v1.Pod) (err error) {
 	}
 
 	// Clean up wstunnel resources if tunnel is enabled and they exist and no VPN annotation
-	if p.config.Network.EnableTunnel && hasExposedPorts(pod) {
-		if _, hasVPN := pod.Annotations["interlink.eu/pod-vpn"]; !hasVPN {
-			wstunnelName := pod.Name + "-" + pod.Namespace
-			p.cleanupWstunnelResources(ctx, wstunnelName, pod.Namespace+"-wstunnel")
-		}
+	if p.shouldCreateWstunnel(pod) {
+		wstunnelName := pod.Name + "-" + pod.Namespace
+		p.cleanupWstunnelResources(ctx, wstunnelName, pod.Namespace+"-wstunnel")
 	}
 
 	now := metav1.Now()


### PR DESCRIPTION
## Summary
- Fixed wstunnel pods/services/ingresses not being cleaned up when main pods are deleted
- Resolved inconsistency between creation and cleanup logic for wstunnel resources

## Problem
Wstunnel infrastructure was not being properly cleaned up due to inconsistent conditions:
- **Creation logic** (`shouldCreateWstunnel`): Checks `hasExposedPorts() || hasExtraPortsAnnotation()`
- **Original cleanup logic**: Only checked `hasExposedPorts()`

This meant pods using only the `interlink.eu/wstunnel-extra-ports` annotation (without container ports) would have wstunnel resources created but never cleaned up.

## Solution
- Changed cleanup logic in `DeletePod` to use `shouldCreateWstunnel(pod)` instead of separate conditions
- Ensures wstunnel resources are cleaned up using the same criteria used for creation
- Prevents orphaned wstunnel pods/services/ingresses

## Changes
- Modified `virtualkubelet.go:1394-1397` to use consistent cleanup logic
- Simplified code by reusing existing `shouldCreateWstunnel` function

## Testing
- ✅ Full project compilation successful (`make all`)
- ✅ golangci-lint passed with 0 issues
- ✅ All binaries built without errors

## Test plan
- [ ] Deploy a pod with only `interlink.eu/wstunnel-extra-ports` annotation (no container ports)
- [ ] Verify wstunnel infrastructure is created
- [ ] Delete the pod
- [ ] Verify wstunnel pods/services/ingresses are properly cleaned up

🤖 Generated with [Claude Code](https://claude.ai/code)