### PR TITLE
Add wait time for cluster readiness in main.go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           verb: call
           args: -s --name unit-tests unit-test
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-          version: "0.19.2"
+          version: "0.19.4"
       - name: Integration Test
         uses: dagger/dagger-for-github@v7
         with:
@@ -30,7 +30,7 @@ jobs:
           verb: call
           args: -s --name slurm-test build-images new-interlink test stdout
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-          version: "0.19.2"
+          version: "0.19.4"
       - name: Integration Test mTLS
         uses: dagger/dagger-for-github@v7
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
           verb: call
           args: -s --name slurm-test-mtls build-images new-interlink-mtls test stdout
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-          version: "0.19.2"
+          version: "0.19.4"

--- a/ci/dagger.json
+++ b/ci/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "interlink",
-  "engineVersion": "v0.19.2",
+  "engineVersion": "v0.19.4",
   "sdk": {
     "source": "go"
   },

--- a/ci/go.mod
+++ b/ci/go.mod
@@ -3,7 +3,7 @@ module dagger/interlink
 go 1.24.0
 
 require (
-	github.com/99designs/gqlgen v0.17.80
+	github.com/99designs/gqlgen v0.17.81
 	github.com/Khan/genqlient v0.8.1
 	github.com/vektah/gqlparser/v2 v2.5.30
 	go.opentelemetry.io/otel v1.38.0
@@ -17,7 +17,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.38.0
 	go.opentelemetry.io/proto/otlp v1.8.0
 	golang.org/x/sync v0.17.0
-	google.golang.org/grpc v1.75.1
+	google.golang.org/grpc v1.76.0
 )
 
 require (

--- a/ci/go.sum
+++ b/ci/go.sum
@@ -1,5 +1,5 @@
-github.com/99designs/gqlgen v0.17.80 h1:S64VF9SK+q3JjQbilgdrM0o4iFQgB54mVQ3QvXEO4Ek=
-github.com/99designs/gqlgen v0.17.80/go.mod h1:vgNcZlLwemsUhYim4dC1pvFP5FX0pr2Y+uYUoHFb1ig=
+github.com/99designs/gqlgen v0.17.81 h1:kCkN/xVyRb5rEQpuwOHRTYq83i0IuTQg9vdIiwEerTs=
+github.com/99designs/gqlgen v0.17.81/go.mod h1:vgNcZlLwemsUhYim4dC1pvFP5FX0pr2Y+uYUoHFb1ig=
 github.com/Khan/genqlient v0.8.1 h1:wtOCc8N9rNynRLXN3k3CnfzheCUNKBcvXmVv5zt6WCs=
 github.com/Khan/genqlient v0.8.1/go.mod h1:R2G6DzjBvCbhjsEajfRjbWdVglSH/73kSivC9TLWVjU=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
@@ -87,8 +87,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5/go.mod h1:j3QtIyytwqGr1JUDtYXwtMXWPKsEa5LtzIFN1Wn5WvE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 h1:eaY8u2EuxbRv7c3NiGK0/NedzVsCcV6hDuU5qPX5EGE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5/go.mod h1:M4/wBTSeyLxupu3W3tJtOgB14jILAS/XWPSSa3TAlJc=
-google.golang.org/grpc v1.75.1 h1:/ODCNEuf9VghjgO3rqLcfg8fiOP0nSluljWFlDxELLI=
-google.golang.org/grpc v1.75.1/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
+google.golang.org/grpc v1.76.0 h1:UnVkv1+uMLYXoIz6o7chp59WfQUYA2ex/BXQ9rHZu7A=
+google.golang.org/grpc v1.76.0/go.mod h1:Ju12QI8M6iQJtbcsV+awF5a4hfJMLi4X0JLo94ULZ6c=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/ci/main.go
+++ b/ci/main.go
@@ -858,6 +858,8 @@ func (m *Interlink) Test(
 		return nil, err
 	}
 
+	time.Sleep(60 * time.Second) // wait for cluster to be ready
+
 	// Automate CSR approval for testing - required for mTLS functionality and log access
 	c = c.WithExec([]string{"bash", "-c", "kubectl get csr -o name | xargs -r kubectl certificate approve"})
 
@@ -900,6 +902,9 @@ func (m *Interlink) TestMTLS(
 	if err != nil {
 		return nil, err
 	}
+
+	time.Sleep(60 * time.Second) // wait for cluster to be ready
+	
 	// Automate CSR approval for testing - required for mTLS functionality and log access
 	c = c.WithExec([]string{"bash", "-c", "kubectl get csr -o name | xargs -r kubectl certificate approve"})
 

--- a/ci/main.go
+++ b/ci/main.go
@@ -370,6 +370,7 @@ EOF`}).
 
 	_, err = m.Kubectl.WithExec([]string{"bash", "-c", `
 for i in {1..60}; do
+	kubectl describe pod -n interlink
   if kubectl get node virtual-kubelet &>/dev/null; then
     echo "Virtual-kubelet node found, waiting for Ready condition..."
     kubectl wait --for=condition=Ready node/virtual-kubelet --timeout=240s && break

--- a/ci/main.go
+++ b/ci/main.go
@@ -358,27 +358,14 @@ EOF`}).
 		WithExec([]string{
 			"helm",
 			"install",
+			"--wait",
+			"--timeout", "600s",
 			"--create-namespace",
 			"-n", "interlink",
 			"virtual-node",
 			"/helm/interlink",
 			"--values", "/manifests/vk_helm_chart.yaml",
 		}).Stdout(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = m.Kubectl.WithExec([]string{"bash", "-c", `
-for i in {1..60}; do
-	kubectl describe pod -n interlink
-  if kubectl get node virtual-kubelet &>/dev/null; then
-    echo "Virtual-kubelet node found, waiting for Ready condition..."
-    kubectl wait --for=condition=Ready node/virtual-kubelet --timeout=240s && break
-  fi
-  echo "Waiting for virtual-kubelet node to be created... ($i/60)"
-  sleep 5
-done
-`}).Stdout(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Added a sleep period to ensure the cluster is ready before proceeding with CSR approval and tests.

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
