### PR TITLE
Prevent empty projected volumes

### DIFF
--- a/pkg/virtualkubelet/execute.go
+++ b/pkg/virtualkubelet/execute.go
@@ -947,7 +947,6 @@ func remoteExecutionHandleVolumes(ctx context.Context, p *Provider, pod *v1.Pod,
 					projectedVolume.Name = volume.Name
 					projectedVolume.Data = make(map[string]string)
 					log.G(ctx).Debug("Adding to PodCreateRequests the projected volume ", volume.Name)
-					req.ProjectedVolumeMaps = append(req.ProjectedVolumeMaps, projectedVolume)
 
 					for _, source := range volume.Projected.Sources {
 						err := remoteExecutionHandleProjectedSource(ctx, p, pod, source, &projectedVolume)
@@ -955,8 +954,10 @@ func remoteExecutionHandleVolumes(ctx context.Context, p *Provider, pod *v1.Pod,
 							return err
 						}
 						failedAndWait = false
-						log.G(ctx).Debug("ProjectedVolumeMaps len: ", len(req.ProjectedVolumeMaps))
 					}
+
+					req.ProjectedVolumeMaps = append(req.ProjectedVolumeMaps, projectedVolume)
+					log.G(ctx).Debug("ProjectedVolumeMaps len: ", len(req.ProjectedVolumeMaps))
 
 				case volume.DownwardAPI != nil:
 					if p.config.DisableProjectedVolumes {


### PR DESCRIPTION

I anticipate that I'm not a Golang programmer, so I may have misinterpreted the code. 

When testing interlink in order to bridge kubernetes with a slurm managed HPC cluster, I experienced empty projected volumes within the slurm jobs created by InterLink. 

Initially I did not set the SHARED_FS=true, so setting it surely solve the problem. But in any case, this pull request seems to correct a bug in the VirtualKubelet code, which can cause the forwarding of an empty projected volume to the slurm bridge.

Apologize in case this is a false alarm.
