### PR TITLE
Mesh contact address

### DIFF
--- a/pkg/virtualkubelet/mesh.go
+++ b/pkg/virtualkubelet/mesh.go
@@ -476,6 +476,7 @@ PersistentKeepalive = %d
 	// Prepare template data
 	data := MeshScriptTemplateData{
 		WGInterfaceName:       wgInterfaceName,
+		MeshContactHost:       fmt.Sprintf("%s.%s.svc.cluster.local", td.Name, td.Namespace),
 		WSTunnelExecutableURL: WSTunnelExecutableURL,
 		WireguardGoURL:        wireguardGoURL,
 		WgToolURL:             wgToolURL,

--- a/pkg/virtualkubelet/mesh_template_test.go
+++ b/pkg/virtualkubelet/mesh_template_test.go
@@ -1,0 +1,24 @@
+package virtualkubelet
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMeshTemplateExportsContactHost(t *testing.T) {
+	content, err := meshScriptTemplate.ReadFile("templates/mesh.sh")
+	require.NoError(t, err)
+
+	tmpl, err := template.New("mesh").Parse(string(content))
+	require.NoError(t, err)
+
+	var rendered bytes.Buffer
+	err = tmpl.Execute(&rendered, MeshScriptTemplateData{
+		MeshContactHost: "worker-tunnel.pods-wstunnel.svc.cluster.local",
+	})
+	require.NoError(t, err)
+	require.Contains(t, rendered.String(), `export INTERLINK_MESH_CONTACT_HOST="worker-tunnel.pods-wstunnel.svc.cluster.local"`)
+}

--- a/pkg/virtualkubelet/templates/mesh.sh
+++ b/pkg/virtualkubelet/templates/mesh.sh
@@ -79,6 +79,7 @@ echo "=== Inside network namespace ==="
 echo "Using WireGuard interface: $WG_IFACE"
 
 export WG_SOCKET_DIR="$TMPDIR"
+export INTERLINK_MESH_CONTACT_HOST="{{.MeshContactHost}}"
 
 # Override /etc/resolv.conf to avoid issues with read-only filesystems
 # Not all environments support this; ignore errors

--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -110,6 +110,7 @@ type PortMapping struct {
 
 type MeshScriptTemplateData struct {
 	WGInterfaceName       string
+	MeshContactHost       string
 	WSTunnelExecutableURL string
 	WireguardGoURL        string
 	WgToolURL             string


### PR DESCRIPTION
Dask workers all use the same private WireGuard address, `10.7.0.2`, so the HTCondor plugin needs a way to tell the scheduler how to reach each individual worker. This change adds each worker’s unique Kubernetes shadow service address to the generated mesh script, allowing the plugin to advertise the correct worker endpoint.

https://github.com/interlink-hq/interlink-htcondor-plugin/pull/32 depends on this change.