### PR TITLE
fix: reduce shadow wstunnel memory usage

### DIFF
--- a/pkg/virtualkubelet/templates/wstunnel-wireguard-template.yaml
+++ b/pkg/virtualkubelet/templates/wstunnel-wireguard-template.yaml
@@ -86,6 +86,9 @@ spec:
       - name: wstunnel
         image: ghcr.io/erebe/wstunnel:latest
         imagePullPolicy: IfNotPresent
+        env:
+        - name: TOKIO_WORKER_THREADS
+          value: "1"
         command: ["bash","-c"]
         args:
           - >


### PR DESCRIPTION
Each FullMesh shadow pod runs its own wstunnel server. Wstunnel defaults its Tokio worker-thread count to the number of CPUs visible on the Kubernetes node, so the small per-worker tunnel process created many unnecessary threads and consumed about 480 MiB on our cluster

Set `TOKIO_WORKER_THREADS=1` for the wstunnel container because each deployment handles one worker tunnel.

Performed Isolated test using the same `ghcr.io/erebe/wstunnel:latest` image with one Tokio thread: 11 MiB
