### PR TITLE
feat: expose interLink server version via API

### DIFF
--- a/cmd/interlink/main.go
+++ b/cmd/interlink/main.go
@@ -193,7 +193,7 @@ func main() {
 	mutex.HandleFunc("/pinglink", interLinkAPIs.Ping)
 	mutex.HandleFunc("/getLogs", interLinkAPIs.GetLogsHandler)
 	mutex.HandleFunc("/updateCache", interLinkAPIs.UpdateCacheHandler)
-	mutex.HandleFunc("/version", api.VersionHandler(virtualkubelet.KubeletVersion))
+	mutex.HandleFunc("/version", api.VersionHandler(interlink.Version))
 
 	interLinkEndpoint := ""
 	switch {

--- a/cmd/interlink/main.go
+++ b/cmd/interlink/main.go
@@ -193,6 +193,7 @@ func main() {
 	mutex.HandleFunc("/pinglink", interLinkAPIs.Ping)
 	mutex.HandleFunc("/getLogs", interLinkAPIs.GetLogsHandler)
 	mutex.HandleFunc("/updateCache", interLinkAPIs.UpdateCacheHandler)
+	mutex.HandleFunc("/version", api.VersionHandler(virtualkubelet.KubeletVersion))
 
 	interLinkEndpoint := ""
 	switch {

--- a/cmd/virtual-kubelet/set-version.sh
+++ b/cmd/virtual-kubelet/set-version.sh
@@ -8,4 +8,9 @@ var (
 	KubeletVersion = "$KUBELET_VERSION"
 )
 EOF
+cat << EOF > pkg/interlink/version.go
+package interlink
+
+var Version = "$KUBELET_VERSION"
+EOF
 fi

--- a/pkg/interlink/api/version.go
+++ b/pkg/interlink/api/version.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// VersionHandler reports the version of the running interLink server.
+func VersionHandler(version string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Version string `json:"version"`
+		}{Version: version})
+	}
+}

--- a/pkg/interlink/api/version.go
+++ b/pkg/interlink/api/version.go
@@ -15,8 +15,10 @@ func VersionHandler(version string) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(struct {
+		if err := json.NewEncoder(w).Encode(struct {
 			Version string `json:"version"`
-		}{Version: version})
+		}{Version: version}); err != nil {
+			return
+		}
 	}
 }

--- a/pkg/interlink/api/version_test.go
+++ b/pkg/interlink/api/version_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionHandlerReturnsRunningVersion(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/version", nil)
+
+	VersionHandler("1.2.3").ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+	require.JSONEq(t, `{"version":"1.2.3"}`, recorder.Body.String())
+}
+
+func TestVersionHandlerRejectsNonGetRequests(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/version", nil)
+
+	VersionHandler("1.2.3").ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
+	require.Equal(t, http.MethodGet, recorder.Header().Get("Allow"))
+}

--- a/pkg/interlink/version.go
+++ b/pkg/interlink/version.go
@@ -1,0 +1,4 @@
+package interlink
+
+// Version is the version of the running interLink server.
+var Version = "test"


### PR DESCRIPTION
## Summary

I added a `GET /version` endpoint so operators can query the version of the running interLink server without shell access. The response uses the same build-time version value already shown by the CLI and startup logs:

```json
{"version":"0.6.2"}
```

I also return `405 Method Not Allowed` with `Allow: GET` for other methods.

## Validation

- `go test -p 1 ./pkg/interlink/api ./cmd/interlink -count=1`
- `go vet ./pkg/interlink/api ./cmd/interlink`
- `git diff --check origin/main...HEAD`

I did not run the K3s end-to-end suite locally because it requires a full cluster environment; the focused handler and server-package checks cover this change.

Fixes #544
