### PR TITLE
540 retry failed remote deletion requests before dropping pods from the virtual kubelet cache

### DIFF
--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -1945,16 +1945,17 @@ func (p *Provider) DeletePod(ctx context.Context, pod *v1.Pod) (err error) {
 		p.cleanupWstunnelResources(ctx, resourceBaseName, wstunnelNS)
 	}
 
+	if err = RemoteExecution(ctx, p.config, p, pod, DELETE); err != nil {
+		log.G(ctx).Error(err)
+		return err
+	}
+
 	now := metav1.Now()
 	pod.Status.Reason = "VKProviderPodDeleted"
 
-	go func() {
-		err = RemoteExecution(ctx, p.config, p, pod, DELETE)
-		if err != nil {
-			log.G(ctx).Error(err)
-			return
-		}
-	}()
+	p.podsMu.Lock()
+	delete(p.pods, string(key))
+	p.podsMu.Unlock()
 
 	for idx := range pod.Status.ContainerStatuses {
 		pod.Status.ContainerStatuses[idx].Ready = false
@@ -1982,11 +1983,6 @@ func (p *Provider) DeletePod(ctx context.Context, pod *v1.Pod) (err error) {
 	if err != nil {
 		return err
 	}
-
-	// delete from p.pods
-	p.podsMu.Lock()
-	delete(p.pods, string(key))
-	p.podsMu.Unlock()
 
 	return nil
 }

--- a/pkg/virtualkubelet/virtualkubelet.go
+++ b/pkg/virtualkubelet/virtualkubelet.go
@@ -73,6 +73,13 @@ const (
 	DefaultWstunnelCommandTLS  = "curl  -L -f -k https://github.com/erebe/wstunnel/releases/download/v10.4.4/wstunnel_10.4.4_linux_amd64.tar.gz -o wstunnel.tar.gz && tar -xzvf wstunnel.tar.gz && chmod +x wstunnel && ./wstunnel client --http-upgrade-path-prefix %s %s wss://%s:443 &"
 )
 
+// Pacing of the pending-deletion reconciliation sweep.
+const (
+	deleteSweepInterval    = 10 * time.Second
+	deleteRetryBaseBackoff = 5 * time.Second
+	deleteRetryMaxBackoff  = 5 * time.Minute
+)
+
 // Annotations for WireGuard and WStunnel configuration
 const (
 	annWGPrivateKey                 = "interlink.eu/wg-private-key"       // base64 or plain (your choice)
@@ -147,6 +154,20 @@ type Provider struct {
 	clientSet            kubernetes.Interface
 	clientHTTPTransport  *http.Transport
 	podIPs               []string
+	pendingDeletes       map[string]*pendingDelete
+	pendingDeletesMu     sync.Mutex
+	deleteLoopOnce       sync.Once
+}
+
+// pendingDelete tracks a pod whose remote deletion has not been confirmed by the
+// plugin yet. Entries live until /delete returns success, so that a pod is never
+// dropped from p.pods (leaving its remote job running) because of a transient
+// plugin outage.
+type pendingDelete struct {
+	pod      *v1.Pod
+	attempts int
+	nextTry  time.Time
+	inFlight bool
 }
 
 // Increment the given IP address
@@ -527,6 +548,7 @@ func NewProviderConfig(
 		internalIP:          internalIP,
 		daemonEndpointPort:  daemonEndpointPort,
 		pods:                make(map[string]*v1.Pod),
+		pendingDeletes:      make(map[string]*pendingDelete),
 		config:              config,
 		startTime:           time.Now(),
 		clientHTTPTransport: clientHTTPTransport,
@@ -1906,6 +1928,12 @@ func (p *Provider) UpdatePod(ctx context.Context, pod *v1.Pod) error {
 }
 
 // DeletePod deletes the specified pod and drops it out of p.pods
+//
+// The pod is registered as pending deletion before the remote call is attempted,
+// and is only dropped from p.pods once the plugin confirms the deletion. A failed
+// attempt is returned to the pod controller so it requeues, and the pod also stays
+// on the reconciliation sweep (deleteLoop) which keeps retrying after the
+// controller has given up. See issue #540.
 func (p *Provider) DeletePod(ctx context.Context, pod *v1.Pod) (err error) {
 	TracerUpdate(&ctx, "DeletePodVK", pod)
 
@@ -1930,17 +1958,39 @@ func (p *Provider) DeletePod(ctx context.Context, pod *v1.Pod) (err error) {
 		}
 	}
 
-	if err = RemoteExecution(ctx, p.config, p, pod, DELETE); err != nil {
+	p.markDeletePending(pod)
+
+	if err = p.deletePodRemote(ctx, pod); err != nil {
 		log.G(ctx).Error(err)
 		return err
 	}
 
-	now := metav1.Now()
-	pod.Status.Reason = "VKProviderPodDeleted"
+	return nil
+}
+
+// deletePodRemote asks the plugin to delete pod and, once it confirms, drops the
+// pod from p.pods and from the pending-deletion set and reports the terminated
+// status to Kubernetes. The remote error is returned untouched so callers can
+// retry; the pod stays tracked until the deletion is confirmed.
+func (p *Provider) deletePodRemote(ctx context.Context, pod *v1.Pod) error {
+	key := string(pod.UID)
+
+	if !p.beginDeleteAttempt(key) {
+		return fmt.Errorf("remote deletion of pod %s/%s is already in progress", pod.Namespace, pod.Name)
+	}
+
+	err := RemoteExecution(ctx, p.config, p, pod, DELETE)
+	p.finishDeleteAttempt(key, err)
+	if err != nil {
+		return err
+	}
 
 	p.podsMu.Lock()
-	delete(p.pods, string(key))
+	delete(p.pods, key)
 	p.podsMu.Unlock()
+
+	now := metav1.Now()
+	pod.Status.Reason = "VKProviderPodDeleted"
 
 	for idx := range pod.Status.ContainerStatuses {
 		pod.Status.ContainerStatuses[idx].Ready = false
@@ -1964,12 +2014,143 @@ func (p *Provider) DeletePod(ctx context.Context, pod *v1.Pod) (err error) {
 	}
 
 	// tell k8s it's terminated
-	err = p.UpdatePod(ctx, pod)
-	if err != nil {
-		return err
+	return p.UpdatePod(ctx, pod)
+}
+
+// markDeletePending registers pod as awaiting confirmation of its remote deletion.
+// Calling it again for a pod already pending keeps the existing attempt count and
+// backoff, so repeated DeletePod calls from the pod controller do not reset it.
+func (p *Provider) markDeletePending(pod *v1.Pod) {
+	p.pendingDeletesMu.Lock()
+	defer p.pendingDeletesMu.Unlock()
+
+	if p.pendingDeletes == nil {
+		p.pendingDeletes = make(map[string]*pendingDelete)
+	}
+	if _, ok := p.pendingDeletes[string(pod.UID)]; !ok {
+		p.pendingDeletes[string(pod.UID)] = &pendingDelete{pod: pod.DeepCopy()}
+	}
+}
+
+// beginDeleteAttempt claims the right to issue a remote deletion for key. It
+// returns false when another attempt is already in flight, which keeps the
+// controller-driven retries and the sweep from issuing duplicate /delete calls.
+func (p *Provider) beginDeleteAttempt(key string) bool {
+	p.pendingDeletesMu.Lock()
+	defer p.pendingDeletesMu.Unlock()
+
+	entry, ok := p.pendingDeletes[key]
+	if !ok {
+		// Not tracked (e.g. a direct call): nothing to serialise against.
+		return true
+	}
+	if entry.inFlight {
+		return false
+	}
+	entry.inFlight = true
+	entry.attempts++
+	return true
+}
+
+// finishDeleteAttempt records the outcome of an attempt: on success the pod stops
+// being tracked, on failure the next attempt is pushed out by an exponential
+// backoff capped at deleteRetryMaxBackoff.
+func (p *Provider) finishDeleteAttempt(key string, err error) {
+	p.pendingDeletesMu.Lock()
+	defer p.pendingDeletesMu.Unlock()
+
+	entry, ok := p.pendingDeletes[key]
+	if !ok {
+		return
+	}
+	if err == nil {
+		delete(p.pendingDeletes, key)
+		return
 	}
 
-	return nil
+	entry.inFlight = false
+	entry.nextTry = time.Now().Add(deleteRetryBackoff(entry.attempts))
+}
+
+// deleteRetryBackoff returns the delay before the given attempt number is retried.
+func deleteRetryBackoff(attempts int) time.Duration {
+	backoff := deleteRetryBaseBackoff
+	for i := 1; i < attempts; i++ {
+		backoff *= 2
+		if backoff >= deleteRetryMaxBackoff {
+			return deleteRetryMaxBackoff
+		}
+	}
+	return backoff
+}
+
+// deleteLoop periodically retries remote deletions that the plugin has not
+// confirmed yet.
+//
+// The pod controller alone is not enough to guarantee delivery: it abandons a pod
+// after queue.MaxRetries, and it stops calling DeletePod entirely once the pod is
+// no longer running (it force-deletes it from the API server instead). Either way
+// the pod would stay in p.pods forever with its remote job still alive, which is
+// the leak described in issue #540. This sweep keeps retrying until /delete
+// succeeds.
+func (p *Provider) deleteLoop(ctx context.Context) {
+	ticker := time.NewTicker(deleteSweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		p.reconcilePendingDeletes(ctx, time.Now())
+	}
+}
+
+// reconcilePendingDeletes retries every pending deletion whose backoff has elapsed
+// at the given time.
+func (p *Provider) reconcilePendingDeletes(ctx context.Context, now time.Time) {
+	for _, pod := range p.pendingDeletesDue(now) {
+		log.G(ctx).Infof("retrying unconfirmed remote deletion of pod %s/%s", pod.Namespace, pod.Name)
+
+		if err := p.deletePodRemote(ctx, pod); err != nil {
+			log.G(ctx).Errorf("remote deletion of pod %s/%s still failing, will retry: %v", pod.Namespace, pod.Name, err)
+			continue
+		}
+
+		log.G(ctx).Infof("remote deletion of pod %s/%s confirmed by the plugin", pod.Namespace, pod.Name)
+	}
+}
+
+// pendingDeletesDue returns the pods whose remote deletion should be retried now.
+// The canonical pod from p.pods is preferred over the copy taken at DeletePod time
+// so that the status reported to Kubernetes on success is the current one.
+func (p *Provider) pendingDeletesDue(now time.Time) []*v1.Pod {
+	p.pendingDeletesMu.Lock()
+	due := make([]string, 0, len(p.pendingDeletes))
+	fallbacks := make(map[string]*v1.Pod, len(p.pendingDeletes))
+	for key, entry := range p.pendingDeletes {
+		if entry.inFlight || now.Before(entry.nextTry) {
+			continue
+		}
+		due = append(due, key)
+		fallbacks[key] = entry.pod
+	}
+	p.pendingDeletesMu.Unlock()
+
+	pods := make([]*v1.Pod, 0, len(due))
+	p.podsMu.RLock()
+	for _, key := range due {
+		if canonical, ok := p.pods[key]; ok {
+			pods = append(pods, canonical.DeepCopy())
+			continue
+		}
+		pods = append(pods, fallbacks[key].DeepCopy())
+	}
+	p.podsMu.RUnlock()
+
+	return pods
 }
 
 func (p *Provider) GetPod(_ context.Context, _ string, _ string) (*v1.Pod, error) {
@@ -2047,6 +2228,10 @@ func (p *Provider) GetPods(ctx context.Context) ([]*v1.Pod, error) {
 	p.podsMu.RUnlock()
 
 	go p.statusLoop(ctx)
+	p.deleteLoopOnce.Do(func() {
+		go p.deleteLoop(ctx)
+	})
+
 	return pods, nil
 }
 

--- a/pkg/virtualkubelet/virtualkubelet_delete_test.go
+++ b/pkg/virtualkubelet/virtualkubelet_delete_test.go
@@ -1,0 +1,95 @@
+package virtualkubelet
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newDeleteTestProvider(t *testing.T, handler http.Handler) (*Provider, *v1.Pod) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	host, port, err := net.SplitHostPort(serverURL.Host)
+	require.NoError(t, err)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: testNamespace,
+			UID:       "test-pod-uid",
+		},
+		Status: v1.PodStatus{Phase: v1.PodRunning},
+	}
+
+	provider := &Provider{
+		config: Config{
+			InterlinkURL:  "http://" + host,
+			InterlinkPort: port,
+		},
+		pods:     map[string]*v1.Pod{string(pod.UID): pod},
+		notifier: func(*v1.Pod) {},
+	}
+
+	return provider, pod
+}
+
+func podIsTracked(provider *Provider, uid string) bool {
+	provider.podsMu.RLock()
+	defer provider.podsMu.RUnlock()
+	_, ok := provider.pods[uid]
+	return ok
+}
+
+func TestDeletePodKeepsPodTrackedUntilRemoteDeletionSucceeds(t *testing.T) {
+	var attempts atomic.Int32
+	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/delete", r.URL.Path)
+
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	provider, pod := newDeleteTestProvider(t, serverHandler)
+
+	err := provider.DeletePod(context.Background(), pod.DeepCopy())
+	require.Error(t, err)
+
+	stillTracked := podIsTracked(provider, string(pod.UID))
+	assert.True(t, stillTracked, "pod must remain tracked when remote deletion fails")
+
+	err = provider.DeletePod(context.Background(), pod.DeepCopy())
+	require.NoError(t, err)
+
+	stillTracked = podIsTracked(provider, string(pod.UID))
+	assert.False(t, stillTracked, "pod must be removed after remote deletion succeeds")
+	assert.Equal(t, int32(2), attempts.Load())
+}
+
+func TestDeletePodDoesNotDropPodWhenRemoteDeletionFails(t *testing.T) {
+	provider, pod := newDeleteTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	err := provider.DeletePod(context.Background(), pod.DeepCopy())
+	require.Error(t, err)
+
+	stillTracked := podIsTracked(provider, string(pod.UID))
+	assert.True(t, stillTracked)
+}

--- a/pkg/virtualkubelet/virtualkubelet_delete_test.go
+++ b/pkg/virtualkubelet/virtualkubelet_delete_test.go
@@ -8,12 +8,15 @@ import (
 	"net/url"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const deleteTestContainer = "main"
 
 func newDeleteTestProvider(t *testing.T, handler http.Handler) (*Provider, *v1.Pod) {
 	t.Helper()
@@ -54,42 +57,145 @@ func podIsTracked(provider *Provider, uid string) bool {
 	return ok
 }
 
+func deleteIsPending(provider *Provider, uid string) bool {
+	provider.pendingDeletesMu.Lock()
+	defer provider.pendingDeletesMu.Unlock()
+	_, ok := provider.pendingDeletes[uid]
+	return ok
+}
+
+// deleteHandler records every /delete call and replies with the given status codes
+// in order, repeating the last one once they are exhausted.
+func deleteHandler(attempts *atomic.Int32, method, path *atomic.Value, statuses ...int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		method.Store(r.Method)
+		path.Store(r.URL.Path)
+
+		idx := int(attempts.Add(1)) - 1
+		if idx >= len(statuses) {
+			idx = len(statuses) - 1
+		}
+		w.WriteHeader(statuses[idx])
+	}
+}
+
 func TestDeletePodKeepsPodTrackedUntilRemoteDeletionSucceeds(t *testing.T) {
 	var attempts atomic.Int32
-	serverHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodDelete, r.Method)
-		require.Equal(t, "/delete", r.URL.Path)
+	var method, path atomic.Value
 
-		if attempts.Add(1) == 1 {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-	provider, pod := newDeleteTestProvider(t, serverHandler)
+	provider, pod := newDeleteTestProvider(t, deleteHandler(&attempts, &method, &path,
+		http.StatusServiceUnavailable, http.StatusOK))
 
 	err := provider.DeletePod(context.Background(), pod.DeepCopy())
 	require.Error(t, err)
 
-	stillTracked := podIsTracked(provider, string(pod.UID))
-	assert.True(t, stillTracked, "pod must remain tracked when remote deletion fails")
+	assert.True(t, podIsTracked(provider, string(pod.UID)), "pod must remain tracked when remote deletion fails")
+	assert.True(t, deleteIsPending(provider, string(pod.UID)), "pod must stay on the retry sweep")
 
 	err = provider.DeletePod(context.Background(), pod.DeepCopy())
 	require.NoError(t, err)
 
-	stillTracked = podIsTracked(provider, string(pod.UID))
-	assert.False(t, stillTracked, "pod must be removed after remote deletion succeeds")
+	assert.False(t, podIsTracked(provider, string(pod.UID)), "pod must be removed after remote deletion succeeds")
+	assert.False(t, deleteIsPending(provider, string(pod.UID)), "pod must leave the retry sweep once confirmed")
 	assert.Equal(t, int32(2), attempts.Load())
+	assert.Equal(t, http.MethodDelete, method.Load())
+	assert.Equal(t, "/delete", path.Load())
 }
 
 func TestDeletePodDoesNotDropPodWhenRemoteDeletionFails(t *testing.T) {
-	provider, pod := newDeleteTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
+	var attempts atomic.Int32
+	var method, path atomic.Value
+
+	provider, pod := newDeleteTestProvider(t, deleteHandler(&attempts, &method, &path,
+		http.StatusInternalServerError))
 
 	err := provider.DeletePod(context.Background(), pod.DeepCopy())
 	require.Error(t, err)
 
-	stillTracked := podIsTracked(provider, string(pod.UID))
-	assert.True(t, stillTracked)
+	assert.True(t, podIsTracked(provider, string(pod.UID)))
+	assert.True(t, deleteIsPending(provider, string(pod.UID)))
+}
+
+// The pod controller stops calling DeletePod once it exhausts its retries, or as
+// soon as the pod is no longer running. The sweep must still finish the job.
+func TestReconcilePendingDeletesRetriesAfterControllerStopsCalling(t *testing.T) {
+	var attempts atomic.Int32
+	var method, path atomic.Value
+
+	provider, pod := newDeleteTestProvider(t, deleteHandler(&attempts, &method, &path,
+		http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusOK))
+
+	// Single failed delete from the controller, which then gives up.
+	require.Error(t, provider.DeletePod(context.Background(), pod.DeepCopy()))
+	require.Equal(t, int32(1), attempts.Load())
+
+	// Second attempt, driven only by the sweep, still fails.
+	provider.reconcilePendingDeletes(context.Background(), time.Now().Add(time.Hour))
+	assert.Equal(t, int32(2), attempts.Load())
+	assert.True(t, podIsTracked(provider, string(pod.UID)))
+
+	// Third attempt succeeds and the pod is finally released.
+	provider.reconcilePendingDeletes(context.Background(), time.Now().Add(2*time.Hour))
+	assert.Equal(t, int32(3), attempts.Load())
+	assert.False(t, podIsTracked(provider, string(pod.UID)), "sweep must drop the pod once the plugin confirms")
+	assert.False(t, deleteIsPending(provider, string(pod.UID)))
+
+	// Nothing left to retry.
+	provider.reconcilePendingDeletes(context.Background(), time.Now().Add(3*time.Hour))
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+func TestReconcilePendingDeletesHonoursBackoff(t *testing.T) {
+	var attempts atomic.Int32
+	var method, path atomic.Value
+
+	provider, pod := newDeleteTestProvider(t, deleteHandler(&attempts, &method, &path,
+		http.StatusServiceUnavailable))
+
+	require.Error(t, provider.DeletePod(context.Background(), pod.DeepCopy()))
+	require.Equal(t, int32(1), attempts.Load())
+
+	// Still inside the backoff window: no request must be issued.
+	provider.reconcilePendingDeletes(context.Background(), time.Now())
+	assert.Equal(t, int32(1), attempts.Load())
+
+	// Past the backoff window: retried.
+	provider.reconcilePendingDeletes(context.Background(), time.Now().Add(deleteRetryBaseBackoff+time.Second))
+	assert.Equal(t, int32(2), attempts.Load())
+}
+
+func TestReconcilePendingDeletesReportsTerminatedStatus(t *testing.T) {
+	var attempts atomic.Int32
+	var method, path atomic.Value
+
+	provider, pod := newDeleteTestProvider(t, deleteHandler(&attempts, &method, &path,
+		http.StatusServiceUnavailable, http.StatusOK))
+
+	provider.podsMu.Lock()
+	provider.pods[string(pod.UID)].Status.ContainerStatuses = []v1.ContainerStatus{
+		{Name: deleteTestContainer, Ready: true, State: v1.ContainerState{Running: &v1.ContainerStateRunning{}}},
+	}
+	provider.podsMu.Unlock()
+
+	var notified *v1.Pod
+	provider.notifier = func(p *v1.Pod) { notified = p }
+
+	require.Error(t, provider.DeletePod(context.Background(), pod.DeepCopy()))
+	require.Nil(t, notified, "no terminated status must be reported while the deletion is unconfirmed")
+
+	provider.reconcilePendingDeletes(context.Background(), time.Now().Add(time.Hour))
+
+	require.NotNil(t, notified, "the sweep must report the terminated status once confirmed")
+	assert.Equal(t, "VKProviderPodDeleted", notified.Status.Reason)
+	require.Len(t, notified.Status.ContainerStatuses, 1)
+	assert.False(t, notified.Status.ContainerStatuses[0].Ready)
+	require.NotNil(t, notified.Status.ContainerStatuses[0].State.Terminated)
+	assert.Equal(t, "VKProviderPodContainerDeleted", notified.Status.ContainerStatuses[0].State.Terminated.Reason)
+}
+
+func TestDeleteRetryBackoffIsCapped(t *testing.T) {
+	assert.Equal(t, deleteRetryBaseBackoff, deleteRetryBackoff(1))
+	assert.Equal(t, 2*deleteRetryBaseBackoff, deleteRetryBackoff(2))
+	assert.Equal(t, 4*deleteRetryBaseBackoff, deleteRetryBackoff(3))
+	assert.Equal(t, deleteRetryMaxBackoff, deleteRetryBackoff(100))
 }


### PR DESCRIPTION
This pull request introduces robust handling and retry logic for remote pod deletions in the `Provider`, addressing the issue where pods could be leaked if the remote plugin failed to confirm deletion (see issue #540). The changes ensure that pods are only removed from tracking once remote deletion is confirmed, and implement a background sweep to retry deletions with exponential backoff. Comprehensive tests have also been added to verify this behavior.

**Pod Deletion Reliability Improvements:**

* Introduced a `pendingDelete` tracking mechanism and associated fields in `Provider` to keep track of pods whose remote deletion has not yet been confirmed, ensuring pods are not dropped prematurely. [[1]](diffhunk://#diff-23ce1addd65bcdd3e1e8d04ae815fa0c71c8f58c6eb9bb9df73091fe5dcd14cfR157-R170) [[2]](diffhunk://#diff-23ce1addd65bcdd3e1e8d04ae815fa0c71c8f58c6eb9bb9df73091fe5dcd14cfR551)
* Refactored `DeletePod` to register pending deletions before attempting remote deletion, and only remove pods from tracking after successful confirmation from the plugin. [[1]](diffhunk://#diff-23ce1addd65bcdd3e1e8d04ae815fa0c71c8f58c6eb9bb9df73091fe5dcd14cfR1931-R1936) [[2]](diffhunk://#diff-23ce1addd65bcdd3e1e8d04ae815fa0c71c8f58c6eb9bb9df73091fe5dcd14cfL1933-R1993)

**Automated Retry Logic:**

* Implemented a periodic background sweep (`deleteLoop`) that retries unconfirmed remote deletions with exponential backoff, ensuring eventual cleanup even if the pod controller gives up. [[1]](diffhunk://#diff-23ce1addd65bcdd3e1e8d04ae815fa0c71c8f58c6eb9bb9df73091fe5dcd14cfL1966-R2153) [[2]](diffhunk://#diff-23ce1addd65bcdd3e1e8d04ae815fa0c71c8f58c6eb9bb9df73091fe5dcd14cfR2231-R2234)
* Added constants to configure sweep interval and backoff timings for deletion retries.

**Testing and Validation:**

* Added a new test file `virtualkubelet_delete_test.go` with comprehensive tests covering deletion retry logic, backoff, and correct status reporting to Kubernetes.